### PR TITLE
Operator cleanup

### DIFF
--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXAggregateTarget section */
 		"Prelude::PreludePackageTests::ProductTarget" /* PreludePackageTests */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_79 /* Build configuration list for PBXAggregateTarget "PreludePackageTests" */;
+			buildConfigurationList = OBJ_85 /* Build configuration list for PBXAggregateTarget "PreludePackageTests" */;
 			buildPhases = (
 			);
 			dependencies = (
-				OBJ_82 /* PBXTargetDependency */,
+				OBJ_88 /* PBXTargetDependency */,
 			);
 			name = PreludePackageTests;
 			productName = PreludePackageTests;
@@ -21,45 +21,46 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		80C28B7D1EF7171000923264 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C28B7C1EF7171000923264 /* KeyPath.swift */; };
-		CA3A92091EF80833009CB76D /* PrecedenceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3A92081EF80833009CB76D /* PrecedenceGroups.swift */; };
-		OBJ_42 /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* ArrayTests.swift */; };
-		OBJ_43 /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* ChoiceTests.swift */; };
-		OBJ_44 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* EitherTests.swift */; };
-		OBJ_45 /* FunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* FunctionTests.swift */; };
-		OBJ_46 /* MonoidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* MonoidTests.swift */; };
-		OBJ_47 /* OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* OptionalTests.swift */; };
-		OBJ_48 /* SemigroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* SemigroupTests.swift */; };
-		OBJ_51 /* SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* SequenceTests.swift */; };
-		OBJ_52 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* StringTests.swift */; };
-		OBJ_53 /* StrongTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* StrongTests.swift */; };
-		OBJ_54 /* TupleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* TupleTests.swift */; };
-		OBJ_55 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* UnitTests.swift */; };
-		OBJ_57 /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Prelude::Prelude::Product" /* Prelude.framework */; };
-		OBJ_64 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Array.swift */; };
-		OBJ_65 /* Choice.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Choice.swift */; };
-		OBJ_66 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Either.swift */; };
-		OBJ_67 /* Function.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Function.swift */; };
-		OBJ_68 /* Monoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Monoid.swift */; };
-		OBJ_69 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Operators.swift */; };
-		OBJ_70 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Optional.swift */; };
-		OBJ_71 /* Semigroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* Semigroup.swift */; };
-		OBJ_72 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Sequence.swift */; };
-		OBJ_73 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* String.swift */; };
-		OBJ_74 /* Strong.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Strong.swift */; };
-		OBJ_75 /* Tuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Tuple.swift */; };
-		OBJ_76 /* Unit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Unit.swift */; };
+		OBJ_47 /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* ArrayTests.swift */; };
+		OBJ_48 /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* ChoiceTests.swift */; };
+		OBJ_49 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* EitherTests.swift */; };
+		OBJ_50 /* FunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* FunctionTests.swift */; };
+		OBJ_51 /* KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* KeyPathTests.swift */; };
+		OBJ_52 /* MonoidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* MonoidTests.swift */; };
+		OBJ_53 /* OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* OptionalTests.swift */; };
+		OBJ_54 /* SemigroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* SemigroupTests.swift */; };
+		OBJ_55 /* SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* SequenceTests.swift */; };
+		OBJ_56 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* StringTests.swift */; };
+		OBJ_57 /* StrongTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* StrongTests.swift */; };
+		OBJ_58 /* TupleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* TupleTests.swift */; };
+		OBJ_59 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* UnitTests.swift */; };
+		OBJ_61 /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Prelude::Prelude::Product" /* Prelude.framework */; };
+		OBJ_68 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Array.swift */; };
+		OBJ_69 /* Choice.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Choice.swift */; };
+		OBJ_70 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Either.swift */; };
+		OBJ_71 /* Function.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* Function.swift */; };
+		OBJ_72 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* KeyPath.swift */; };
+		OBJ_73 /* Monoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* Monoid.swift */; };
+		OBJ_74 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Operators.swift */; };
+		OBJ_75 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* Optional.swift */; };
+		OBJ_76 /* PrecedenceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* PrecedenceGroups.swift */; };
+		OBJ_77 /* Semigroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* Semigroup.swift */; };
+		OBJ_78 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Sequence.swift */; };
+		OBJ_79 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* String.swift */; };
+		OBJ_80 /* Strong.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Strong.swift */; };
+		OBJ_81 /* Tuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* Tuple.swift */; };
+		OBJ_82 /* Unit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Unit.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		80C28B571EF6E4D100923264 /* PBXContainerItemProxy */ = {
+		CA3A920A1EF80F07009CB76D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Prelude::Prelude";
 			remoteInfo = Prelude;
 		};
-		80C28B581EF6E4D100923264 /* PBXContainerItemProxy */ = {
+		CA3A920B1EF80F08009CB76D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -69,32 +70,33 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		80C28B7C1EF7171000923264 /* KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
-		CA3A92081EF80833009CB76D /* PrecedenceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrecedenceGroups.swift; sourceTree = "<group>"; };
 		OBJ_10 /* Choice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Choice.swift; sourceTree = "<group>"; };
 		OBJ_11 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Function.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function.swift; sourceTree = "<group>"; };
-		OBJ_13 /* Monoid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Monoid.swift; sourceTree = "<group>"; };
-		OBJ_14 /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
-		OBJ_15 /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
-		OBJ_16 /* Semigroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semigroup.swift; sourceTree = "<group>"; };
-		OBJ_17 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
-		OBJ_18 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
-		OBJ_19 /* Strong.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strong.swift; sourceTree = "<group>"; };
-		OBJ_20 /* Tuple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple.swift; sourceTree = "<group>"; };
-		OBJ_21 /* Unit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unit.swift; sourceTree = "<group>"; };
-		OBJ_24 /* ArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
-		OBJ_25 /* ChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceTests.swift; sourceTree = "<group>"; };
-		OBJ_26 /* EitherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
-		OBJ_27 /* FunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionTests.swift; sourceTree = "<group>"; };
-		OBJ_28 /* MonoidTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonoidTests.swift; sourceTree = "<group>"; };
-		OBJ_29 /* OptionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalTests.swift; sourceTree = "<group>"; };
-		OBJ_30 /* SemigroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemigroupTests.swift; sourceTree = "<group>"; };
-		OBJ_31 /* SequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
-		OBJ_32 /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
-		OBJ_33 /* StrongTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrongTests.swift; sourceTree = "<group>"; };
-		OBJ_34 /* TupleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TupleTests.swift; sourceTree = "<group>"; };
-		OBJ_35 /* UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTests.swift; sourceTree = "<group>"; };
+		OBJ_13 /* KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
+		OBJ_14 /* Monoid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Monoid.swift; sourceTree = "<group>"; };
+		OBJ_15 /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		OBJ_16 /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
+		OBJ_17 /* PrecedenceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrecedenceGroups.swift; sourceTree = "<group>"; };
+		OBJ_18 /* Semigroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semigroup.swift; sourceTree = "<group>"; };
+		OBJ_19 /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
+		OBJ_20 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		OBJ_21 /* Strong.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strong.swift; sourceTree = "<group>"; };
+		OBJ_22 /* Tuple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tuple.swift; sourceTree = "<group>"; };
+		OBJ_23 /* Unit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unit.swift; sourceTree = "<group>"; };
+		OBJ_26 /* ArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
+		OBJ_27 /* ChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceTests.swift; sourceTree = "<group>"; };
+		OBJ_28 /* EitherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
+		OBJ_29 /* FunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionTests.swift; sourceTree = "<group>"; };
+		OBJ_30 /* KeyPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathTests.swift; sourceTree = "<group>"; };
+		OBJ_31 /* MonoidTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonoidTests.swift; sourceTree = "<group>"; };
+		OBJ_32 /* OptionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalTests.swift; sourceTree = "<group>"; };
+		OBJ_33 /* SemigroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemigroupTests.swift; sourceTree = "<group>"; };
+		OBJ_34 /* SequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
+		OBJ_35 /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
+		OBJ_36 /* StrongTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrongTests.swift; sourceTree = "<group>"; };
+		OBJ_37 /* TupleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TupleTests.swift; sourceTree = "<group>"; };
+		OBJ_38 /* UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTests.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_9 /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		"Prelude::Prelude::Product" /* Prelude.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -102,15 +104,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		OBJ_56 /* Frameworks */ = {
+		OBJ_60 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_57 /* Prelude.framework in Frameworks */,
+				OBJ_61 /* Prelude.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_77 /* Frameworks */ = {
+		OBJ_83 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -120,36 +122,36 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		OBJ_22 /* Tests */ = {
+		OBJ_24 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_23 /* PreludeTests */,
+				OBJ_25 /* PreludeTests */,
 			);
 			name = Tests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_23 /* PreludeTests */ = {
+		OBJ_25 /* PreludeTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_24 /* ArrayTests.swift */,
-				OBJ_25 /* ChoiceTests.swift */,
-				OBJ_26 /* EitherTests.swift */,
-				OBJ_27 /* FunctionTests.swift */,
-				80C28B7E1EF717E300923264 /* KeyPathTests.swift */,
-				OBJ_28 /* MonoidTests.swift */,
-				OBJ_29 /* OptionalTests.swift */,
-				OBJ_30 /* SemigroupTests.swift */,
-				OBJ_31 /* SequenceTests.swift */,
-				OBJ_32 /* StringTests.swift */,
-				OBJ_33 /* StrongTests.swift */,
-				OBJ_34 /* TupleTests.swift */,
-				OBJ_35 /* UnitTests.swift */,
+				OBJ_26 /* ArrayTests.swift */,
+				OBJ_27 /* ChoiceTests.swift */,
+				OBJ_28 /* EitherTests.swift */,
+				OBJ_29 /* FunctionTests.swift */,
+				OBJ_30 /* KeyPathTests.swift */,
+				OBJ_31 /* MonoidTests.swift */,
+				OBJ_32 /* OptionalTests.swift */,
+				OBJ_33 /* SemigroupTests.swift */,
+				OBJ_34 /* SequenceTests.swift */,
+				OBJ_35 /* StringTests.swift */,
+				OBJ_36 /* StrongTests.swift */,
+				OBJ_37 /* TupleTests.swift */,
+				OBJ_38 /* UnitTests.swift */,
 			);
 			name = PreludeTests;
 			path = Tests/PreludeTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_36 /* Products */ = {
+		OBJ_39 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				"Prelude::PreludeTests::Product" /* PreludeTests.xctest */,
@@ -158,14 +160,15 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 = {
+		OBJ_5 /*  */ = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
 				OBJ_7 /* Sources */,
-				OBJ_22 /* Tests */,
-				OBJ_36 /* Products */,
+				OBJ_24 /* Tests */,
+				OBJ_39 /* Products */,
 			);
+			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -183,16 +186,17 @@
 				OBJ_10 /* Choice.swift */,
 				OBJ_11 /* Either.swift */,
 				OBJ_12 /* Function.swift */,
-				80C28B7C1EF7171000923264 /* KeyPath.swift */,
-				OBJ_13 /* Monoid.swift */,
-				OBJ_14 /* Operators.swift */,
-				OBJ_15 /* Optional.swift */,
-				OBJ_16 /* Semigroup.swift */,
-				OBJ_17 /* String.swift */,
-				OBJ_18 /* Strong.swift */,
-				OBJ_19 /* Tuple.swift */,
-				OBJ_20 /* Unit.swift */,
-				CA3A92081EF80833009CB76D /* PrecedenceGroups.swift */,
+				OBJ_13 /* KeyPath.swift */,
+				OBJ_14 /* Monoid.swift */,
+				OBJ_15 /* Operators.swift */,
+				OBJ_16 /* Optional.swift */,
+				OBJ_17 /* PrecedenceGroups.swift */,
+				OBJ_18 /* Semigroup.swift */,
+				OBJ_19 /* Sequence.swift */,
+				OBJ_20 /* String.swift */,
+				OBJ_21 /* Strong.swift */,
+				OBJ_22 /* Tuple.swift */,
+				OBJ_23 /* Unit.swift */,
 			);
 			name = Prelude;
 			path = Sources/Prelude;
@@ -203,10 +207,10 @@
 /* Begin PBXNativeTarget section */
 		"Prelude::Prelude" /* Prelude */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_60 /* Build configuration list for PBXNativeTarget "Prelude" */;
+			buildConfigurationList = OBJ_64 /* Build configuration list for PBXNativeTarget "Prelude" */;
 			buildPhases = (
-				OBJ_63 /* Sources */,
-				OBJ_77 /* Frameworks */,
+				OBJ_67 /* Sources */,
+				OBJ_83 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -219,15 +223,15 @@
 		};
 		"Prelude::PreludeTests" /* PreludeTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_40 /* Build configuration list for PBXNativeTarget "PreludeTests" */;
+			buildConfigurationList = OBJ_43 /* Build configuration list for PBXNativeTarget "PreludeTests" */;
 			buildPhases = (
-				OBJ_43 /* Sources */,
-				OBJ_56 /* Frameworks */,
+				OBJ_46 /* Sources */,
+				OBJ_60 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_58 /* PBXTargetDependency */,
+				OBJ_62 /* PBXTargetDependency */,
 			);
 			name = PreludeTests;
 			productName = PreludeTests;
@@ -249,8 +253,8 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_36 /* Products */;
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_39 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -262,59 +266,60 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		OBJ_43 /* Sources */ = {
+		OBJ_46 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_44 /* ArrayTests.swift in Sources */,
-				OBJ_45 /* ChoiceTests.swift in Sources */,
-				OBJ_46 /* EitherTests.swift in Sources */,
-				OBJ_47 /* FunctionTests.swift in Sources */,
-				OBJ_48 /* MonoidTests.swift in Sources */,
-				OBJ_49 /* OptionalTests.swift in Sources */,
-				OBJ_50 /* SemigroupTests.swift in Sources */,
-				OBJ_51 /* SequenceTests.swift in Sources */,
-				OBJ_52 /* StringTests.swift in Sources */,
-				OBJ_53 /* StrongTests.swift in Sources */,
-				OBJ_54 /* TupleTests.swift in Sources */,
-				OBJ_55 /* UnitTests.swift in Sources */,
-				80C28B7F1EF717E300923264 /* KeyPathTests.swift in Sources */,
+				OBJ_47 /* ArrayTests.swift in Sources */,
+				OBJ_48 /* ChoiceTests.swift in Sources */,
+				OBJ_49 /* EitherTests.swift in Sources */,
+				OBJ_50 /* FunctionTests.swift in Sources */,
+				OBJ_51 /* KeyPathTests.swift in Sources */,
+				OBJ_52 /* MonoidTests.swift in Sources */,
+				OBJ_53 /* OptionalTests.swift in Sources */,
+				OBJ_54 /* SemigroupTests.swift in Sources */,
+				OBJ_55 /* SequenceTests.swift in Sources */,
+				OBJ_56 /* StringTests.swift in Sources */,
+				OBJ_57 /* StrongTests.swift in Sources */,
+				OBJ_58 /* TupleTests.swift in Sources */,
+				OBJ_59 /* UnitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_63 /* Sources */ = {
+		OBJ_67 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_64 /* Array.swift in Sources */,
-				OBJ_65 /* Choice.swift in Sources */,
-				80C28B7D1EF7171000923264 /* KeyPath.swift in Sources */,
-				OBJ_63 /* Either.swift in Sources */,
-				OBJ_64 /* Function.swift in Sources */,
-				OBJ_65 /* Monoid.swift in Sources */,
-				OBJ_66 /* Operators.swift in Sources */,
-				OBJ_67 /* Optional.swift in Sources */,
-				OBJ_68 /* Semigroup.swift in Sources */,
-				OBJ_69 /* String.swift in Sources */,
-				CA3A92091EF80833009CB76D /* PrecedenceGroups.swift in Sources */,
-				OBJ_70 /* Strong.swift in Sources */,
-				OBJ_71 /* Tuple.swift in Sources */,
-				OBJ_72 /* Unit.swift in Sources */,
+				OBJ_68 /* Array.swift in Sources */,
+				OBJ_69 /* Choice.swift in Sources */,
+				OBJ_70 /* Either.swift in Sources */,
+				OBJ_71 /* Function.swift in Sources */,
+				OBJ_72 /* KeyPath.swift in Sources */,
+				OBJ_73 /* Monoid.swift in Sources */,
+				OBJ_74 /* Operators.swift in Sources */,
+				OBJ_75 /* Optional.swift in Sources */,
+				OBJ_76 /* PrecedenceGroups.swift in Sources */,
+				OBJ_77 /* Semigroup.swift in Sources */,
+				OBJ_78 /* Sequence.swift in Sources */,
+				OBJ_79 /* String.swift in Sources */,
+				OBJ_80 /* Strong.swift in Sources */,
+				OBJ_81 /* Tuple.swift in Sources */,
+				OBJ_82 /* Unit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_58 /* PBXTargetDependency */ = {
+		OBJ_62 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Prelude::Prelude" /* Prelude */;
-			targetProxy = 80C28B571EF6E4D100923264 /* PBXContainerItemProxy */;
+			targetProxy = CA3A920A1EF80F07009CB76D /* PBXContainerItemProxy */;
 		};
-		OBJ_82 /* PBXTargetDependency */ = {
+		OBJ_88 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Prelude::PreludeTests" /* PreludeTests */;
-			targetProxy = 80C28B581EF6E4D100923264 /* PBXContainerItemProxy */;
+			targetProxy = CA3A920B1EF80F08009CB76D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -363,7 +368,7 @@
 			};
 			name = Release;
 		};
-		OBJ_41 /* Debug */ = {
+		OBJ_44 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
@@ -380,7 +385,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_42 /* Release */ = {
+		OBJ_45 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
@@ -397,7 +402,7 @@
 			};
 			name = Release;
 		};
-		OBJ_61 /* Debug */ = {
+		OBJ_65 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -418,7 +423,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_62 /* Release */ = {
+		OBJ_66 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -439,13 +444,13 @@
 			};
 			name = Release;
 		};
-		OBJ_80 /* Debug */ = {
+		OBJ_86 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		OBJ_81 /* Release */ = {
+		OBJ_87 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
@@ -463,29 +468,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		OBJ_40 /* Build configuration list for PBXNativeTarget "PreludeTests" */ = {
+		OBJ_43 /* Build configuration list for PBXNativeTarget "PreludeTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_41 /* Debug */,
-				OBJ_42 /* Release */,
+				OBJ_44 /* Debug */,
+				OBJ_45 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		OBJ_60 /* Build configuration list for PBXNativeTarget "Prelude" */ = {
+		OBJ_64 /* Build configuration list for PBXNativeTarget "Prelude" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_61 /* Debug */,
-				OBJ_62 /* Release */,
+				OBJ_65 /* Debug */,
+				OBJ_66 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		OBJ_79 /* Build configuration list for PBXAggregateTarget "PreludePackageTests" */ = {
+		OBJ_85 /* Build configuration list for PBXAggregateTarget "PreludePackageTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_80 /* Debug */,
-				OBJ_81 /* Release */,
+				OBJ_86 /* Debug */,
+				OBJ_87 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Prelude.xcodeproj/project.pbxproj
+++ b/Prelude.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		CA3A92091EF80833009CB76D /* PrecedenceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3A92081EF80833009CB76D /* PrecedenceGroups.swift */; };
 		OBJ_42 /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* ArrayTests.swift */; };
 		OBJ_43 /* ChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* ChoiceTests.swift */; };
 		OBJ_44 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* EitherTests.swift */; };
@@ -65,6 +66,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CA3A92081EF80833009CB76D /* PrecedenceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrecedenceGroups.swift; sourceTree = "<group>"; };
 		OBJ_10 /* Choice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Choice.swift; sourceTree = "<group>"; };
 		OBJ_11 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Function.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function.swift; sourceTree = "<group>"; };
@@ -148,7 +150,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -156,7 +158,6 @@
 				OBJ_21 /* Tests */,
 				OBJ_34 /* Products */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -182,6 +183,7 @@
 				OBJ_18 /* Strong.swift */,
 				OBJ_19 /* Tuple.swift */,
 				OBJ_20 /* Unit.swift */,
+				CA3A92081EF80833009CB76D /* PrecedenceGroups.swift */,
 			);
 			name = Prelude;
 			path = Sources/Prelude;
@@ -238,7 +240,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_34 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -282,6 +284,7 @@
 				OBJ_67 /* Optional.swift in Sources */,
 				OBJ_68 /* Semigroup.swift in Sources */,
 				OBJ_69 /* String.swift in Sources */,
+				CA3A92091EF80833009CB76D /* PrecedenceGroups.swift in Sources */,
 				OBJ_70 /* Strong.swift in Sources */,
 				OBJ_71 /* Tuple.swift in Sources */,
 				OBJ_72 /* Unit.swift in Sources */,

--- a/Sources/Prelude/Function.swift
+++ b/Sources/Prelude/Function.swift
@@ -21,3 +21,9 @@ public func <| <A, B> (f: (A) -> B, a: A) -> B {
 public func |> <A, B> (a: A, f: (A) -> B) -> B {
   return f(a)
 }
+
+public func uncurry<A, B, C>(_ f: @escaping (A) -> (B) -> C) -> (A, B) -> C {
+  return { a, b in
+    f(a)(b)
+  }
+}

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -1,62 +1,88 @@
-precedencegroup HashRocket {
-  associativity: left
-  higherThan: Semigroup
-}
-infix operator =>: HashRocket
-
-precedencegroup Alt {
-  associativity: left
+precedencegroup SemigroupoidCompose { // infixr 9
+  associativity: right
+  higherThan: SemigroupAppend
 }
 
-precedencegroup Apply {
-  higherThan: Alt
-  associativity: left
-}
-
-precedencegroup Functor {
-  higherThan: Apply
-  associativity: left
-}
-
-precedencegroup FunctionApplication {
-  associativity: left
-  higherThan: Semigroup
-}
-
-precedencegroup FunctionApplicationFlipped {
-  associativity: left
-  higherThan: FunctionApplication
-}
-
-precedencegroup Semigroup {
+precedencegroup SemigroupAppend { // infixr 5
   associativity: right
   higherThan: AdditionPrecedence
   lowerThan: MultiplicationPrecedence
 }
 
-precedencegroup FunctionComposition {
+precedencegroup FunctionApply { // infixr 0
   associativity: right
 }
 
-precedencegroup MonadicBind {
-  associativity: right
+precedencegroup FunctionApplyFlipped { // infixl 1
+  associativity: left
+  higherThan: FunctionApply
 }
 
+precedencegroup FunctorMap { // infixl 4
+  associativity: left
+  higherThan: ApplicativeApply
+}
 
-infix operator <<<: FunctionComposition
-infix operator >>>: FunctionComposition
-infix operator <|: FunctionApplication
-infix operator |>: FunctionApplicationFlipped
-infix operator <|>: Alt
-infix operator <*>: Apply
-infix operator <*: Apply
-infix operator *>: Apply
+precedencegroup FunctorMapFlipped { // infixl 1
+  associativity: left
+  higherThan: FunctionApplyFlipped
+}
 
-infix operator <¢>: Functor
-infix operator <¢: Functor
+precedencegroup Alt { // infixl 3
+  associativity: left
+}
 
-infix operator <>: Semigroup
+precedencegroup ApplicativeApply { // infixl 4
+  associativity: left
+  higherThan: Alt
+}
+
+precedencegroup MonadFlatMap { // infixl 1
+  associativity: left
+  higherThan: FunctorMapFlipped
+}
+
+precedencegroup MonadFlatMapFlipped { // infixr 1
+  associativity: right
+  higherThan: FunctionApply
+}
+
+precedencegroup KleisliCompose { // infixr 1
+  associativity: right
+  higherThan: MonadFlatMapFlipped
+}
+
+infix operator >>>: SemigroupoidCompose
+infix operator <<<: SemigroupoidCompose
+
+infix operator <>: SemigroupAppend
 prefix operator <>
 postfix operator <>
 
-infix operator >>-: MonadicBind
+infix operator <|: FunctionApply
+infix operator |>: FunctionApplyFlipped
+
+infix operator <¢>: FunctorMap
+infix operator ¢>: FunctorMap
+infix operator <¢: FunctorMap
+infix operator <£>: FunctorMapFlipped
+
+infix operator <|>: Alt
+
+infix operator <*>: ApplicativeApply
+infix operator *>: ApplicativeApply
+infix operator <*: ApplicativeApply
+
+infix operator >>-: MonadFlatMap
+infix operator -<<: MonadFlatMapFlipped
+infix operator >->: KleisliCompose
+infix operator <-<: KleisliCompose
+
+// Non-standard
+
+precedencegroup HashRocket {
+  associativity: left
+  higherThan: SemigroupAppend
+}
+
+infix operator =>: HashRocket

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -9,13 +9,18 @@ precedencegroup SemigroupAppend { // infixr 5
   lowerThan: MultiplicationPrecedence
 }
 
-precedencegroup FunctionApply { // infixr 0
+precedencegroup FunctionApplyLow { // infixr 0
   associativity: right
+}
+
+precedencegroup FunctionApplyHigh { // infixl 9
+  associativity: left
+  higherThan: SemigroupoidCompose
 }
 
 precedencegroup FunctionApplyFlipped { // infixl 1
   associativity: left
-  higherThan: FunctionApply
+  higherThan: FunctionApplyLow
 }
 
 precedencegroup FunctorMap { // infixl 4
@@ -44,7 +49,7 @@ precedencegroup MonadFlatMap { // infixl 1
 
 precedencegroup MonadFlatMapFlipped { // infixr 1
   associativity: right
-  higherThan: FunctionApply
+  higherThan: FunctionApplyLow
 }
 
 precedencegroup KleisliCompose { // infixr 1
@@ -59,7 +64,8 @@ infix operator <>: SemigroupAppend
 prefix operator <>
 postfix operator <>
 
-infix operator <|: FunctionApply
+infix operator ¢: FunctionApplyLow
+infix operator <|: FunctionApplyHigh
 infix operator |>: FunctionApplyFlipped
 
 infix operator <¢>: FunctorMap

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -28,6 +28,11 @@ precedencegroup FunctorMapFlipped { // infixl 1
   higherThan: FunctionApplyFlipped
 }
 
+precedencegroup ContravariantMap { // infixl 4
+  associativity: left
+  higherThan: FunctorMap
+}
+
 precedencegroup Alt { // infixl 3
   associativity: left
 }
@@ -66,6 +71,9 @@ infix operator <¢>: FunctorMap
 infix operator ¢>: FunctorMap
 infix operator <¢: FunctorMap
 infix operator <£>: FunctorMapFlipped
+
+infix operator >¢<: ContravariantMap
+infix operator >£<: ContravariantMap
 
 infix operator <|>: Alt
 

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -8,9 +8,9 @@ postfix operator <>
 infix operator <|: infixr0
 infix operator |>: infixl1
 
-infix operator <¢>: infixr4
-infix operator ¢>: infixr4
-infix operator <¢: infixr4
+infix operator <¢>: infixl4
+infix operator ¢>: infixl4
+infix operator <¢: infixl4
 infix operator <£>: infixl1
 
 infix operator >¢<: infixl4

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -9,18 +9,13 @@ precedencegroup SemigroupAppend { // infixr 5
   lowerThan: MultiplicationPrecedence
 }
 
-precedencegroup FunctionApplyLow { // infixr 0
+precedencegroup FunctionApply { // infixr 0
   associativity: right
-}
-
-precedencegroup FunctionApplyHigh { // infixl 9
-  associativity: left
-  higherThan: SemigroupoidCompose
 }
 
 precedencegroup FunctionApplyFlipped { // infixl 1
   associativity: left
-  higherThan: FunctionApplyLow
+  higherThan: FunctionApply
 }
 
 precedencegroup FunctorMap { // infixl 4
@@ -49,7 +44,7 @@ precedencegroup MonadFlatMap { // infixl 1
 
 precedencegroup MonadFlatMapFlipped { // infixr 1
   associativity: right
-  higherThan: FunctionApplyLow
+  higherThan: FunctionApply
 }
 
 precedencegroup KleisliCompose { // infixr 1
@@ -64,8 +59,7 @@ infix operator <>: SemigroupAppend
 prefix operator <>
 postfix operator <>
 
-infix operator ¢: FunctionApplyLow
-infix operator <|: FunctionApplyHigh
+infix operator <|: FunctionApply
 infix operator |>: FunctionApplyFlipped
 
 infix operator <¢>: FunctorMap

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -1,96 +1,37 @@
-precedencegroup SemigroupoidCompose { // infixr 9
-  associativity: right
-  higherThan: SemigroupAppend
-}
+infix operator >>>: infixr9
+infix operator <<<: infixr9
 
-precedencegroup SemigroupAppend { // infixr 5
-  associativity: right
-  higherThan: AdditionPrecedence
-  lowerThan: MultiplicationPrecedence
-}
-
-precedencegroup FunctionApply { // infixr 0
-  associativity: right
-}
-
-precedencegroup FunctionApplyFlipped { // infixl 1
-  associativity: left
-  higherThan: FunctionApply
-}
-
-precedencegroup FunctorMap { // infixl 4
-  associativity: left
-  higherThan: ApplicativeApply
-}
-
-precedencegroup FunctorMapFlipped { // infixl 1
-  associativity: left
-  higherThan: FunctionApplyFlipped
-}
-
-precedencegroup ContravariantMap { // infixl 4
-  associativity: left
-  higherThan: FunctorMap
-}
-
-precedencegroup Alt { // infixl 3
-  associativity: left
-}
-
-precedencegroup ApplicativeApply { // infixl 4
-  associativity: left
-  higherThan: Alt
-}
-
-precedencegroup MonadFlatMap { // infixl 1
-  associativity: left
-  higherThan: FunctorMapFlipped
-}
-
-precedencegroup MonadFlatMapFlipped { // infixr 1
-  associativity: right
-  higherThan: FunctionApply
-}
-
-precedencegroup KleisliCompose { // infixr 1
-  associativity: right
-  higherThan: MonadFlatMapFlipped
-}
-
-infix operator >>>: SemigroupoidCompose
-infix operator <<<: SemigroupoidCompose
-
-infix operator <>: SemigroupAppend
+infix operator <>: infixr5
 prefix operator <>
 postfix operator <>
 
-infix operator <|: FunctionApply
-infix operator |>: FunctionApplyFlipped
+infix operator <|: infixr0
+infix operator |>: infixl1
 
-infix operator <¢>: FunctorMap
-infix operator ¢>: FunctorMap
-infix operator <¢: FunctorMap
-infix operator <£>: FunctorMapFlipped
+infix operator <¢>: infixr4
+infix operator ¢>: infixr4
+infix operator <¢: infixr4
+infix operator <£>: infixl1
 
-infix operator >¢<: ContravariantMap
-infix operator >£<: ContravariantMap
+infix operator >¢<: infixl4
+infix operator >£<: infixl4
 
-infix operator <|>: Alt
+infix operator <|>: infixl3
 
-infix operator <*>: ApplicativeApply
-infix operator *>: ApplicativeApply
-infix operator <*: ApplicativeApply
+infix operator <*>: infixl4
+infix operator *>: infixl4
+infix operator <*: infixl4
 
-infix operator >>-: MonadFlatMap
-infix operator -<<: MonadFlatMapFlipped
-infix operator >->: KleisliCompose
-infix operator <-<: KleisliCompose
+infix operator >>-: infixl1
+infix operator -<<: infixr1
+infix operator >->: infixr1
+infix operator <-<: infixr1
 
 // Non-standard
 
 precedencegroup HashRocket {
   associativity: left
-  higherThan: SemigroupAppend
+  higherThan: infixr5
 }
 
 infix operator =>: HashRocket

--- a/Sources/Prelude/PrecedenceGroups.swift
+++ b/Sources/Prelude/PrecedenceGroups.swift
@@ -1,0 +1,79 @@
+precedencegroup infixr0 {
+  associativity: right
+}
+precedencegroup infixr1 {
+  associativity: right
+  higherThan: infixr0
+}
+precedencegroup infixr2 {
+  associativity: right
+  higherThan: infixr1
+}
+precedencegroup infixr3 {
+  associativity: right
+  higherThan: infixr2
+}
+precedencegroup infixr4 {
+  associativity: right
+  higherThan: infixr3
+}
+precedencegroup infixr5 {
+  associativity: right
+  higherThan: infixr4
+}
+precedencegroup infixr6 {
+  associativity: right
+  higherThan: infixr5
+}
+precedencegroup infixr7 {
+  associativity: right
+  higherThan: infixr6
+}
+precedencegroup infixr8 {
+  associativity: right
+  higherThan: infixr7
+}
+precedencegroup infixr9 {
+  associativity: right
+  higherThan: infixr8
+}
+
+precedencegroup infixl0 {
+  associativity: left
+}
+precedencegroup infixl1 {
+  associativity: left
+  higherThan: infixl0
+}
+precedencegroup infixl2 {
+  associativity: left
+  higherThan: infixl1
+}
+precedencegroup infixl3 {
+  associativity: left
+  higherThan: infixl2
+}
+precedencegroup infixl4 {
+  associativity: left
+  higherThan: infixl3
+}
+precedencegroup infixl5 {
+  associativity: left
+  higherThan: infixl4
+}
+precedencegroup infixl6 {
+  associativity: left
+  higherThan: infixl5
+}
+precedencegroup infixl7 {
+  associativity: left
+  higherThan: infixl6
+}
+precedencegroup infixl8 {
+  associativity: left
+  higherThan: infixl7
+}
+precedencegroup infixl9 {
+  associativity: left
+  higherThan: infixl8
+}


### PR DESCRIPTION
This takes inspiration and naming from PureScript. One thing to note is our associativity and precedence of `<|`, which differs from `$` (and a pending `¢` operator in here). There's a part of our CSS lib that broke when I tried mirroring the associativity/precedence of `$`. A simple example of the issue:

``` swift
add <| 1 <| 2 // fails
(add <| 1) <| 2 // succeeds
```

I think the idea is that `$` (and maybe `<|`) are meant to apply a single argument to a chain of composed functions.

``` swift
incr <<< incr <<< incr <| x
x |> incr >>> incr >>> incr
```

We're using `<|` as a shorthand for the high-precedence whitespace application in PureScript/Haskell.

Maybe we shouldn't, though? Maybe we should embrace the parens of Swift?

``` swift
return add(x)(y)

// or, using some bound variables:
let xPlus = add(x)
return xPlus(y)
```

Thoughts?