### PR TITLE
Added function protocol and concrete types.

### DIFF
--- a/Sources/Prelude/Function.swift
+++ b/Sources/Prelude/Function.swift
@@ -1,3 +1,13 @@
+public struct Function<A, B>: FunctionProtocol {
+  public typealias Source = A
+  public typealias Target = B
+
+  public let call: (A) -> B
+  public init(_ call: @escaping (A) -> B) {
+    self.call = call
+  }
+}
+
 public func id<A>(_ a: A) -> A {
   return a
 }

--- a/Sources/Prelude/FunctionM.swift
+++ b/Sources/Prelude/FunctionM.swift
@@ -1,4 +1,6 @@
-public struct FunctionM<A, M: Monoid> {
+public struct FunctionM<A, M: Monoid>: FunctionProtocol {
+  public typealias Source = A
+  public typealias Target = M
   public let call: (A) -> M
 
   public init(_ call: @escaping (A) -> M) {
@@ -21,67 +23,5 @@ extension FunctionM: Semigroup {
 extension FunctionM: Monoid {
   public static var e: FunctionM {
     return FunctionM(const(M.e))
-  }
-}
-
-// MARK: - Functor
-
-extension FunctionM {
-  public func map<N>(_ f: @escaping (M) -> N) -> FunctionM<A, N> {
-    return .init(self.call >>> f)
-  }
-
-  public static func <¢> <D, N, S>(f: @escaping (N) -> S, g: FunctionM<D, N>) -> FunctionM<D, S> {
-    return g.map(f)
-  }
-}
-
-public func map<A, M, N>(_ f: @escaping (M) -> N) -> (FunctionM<A, M>) -> FunctionM<A, N> {
-  return { g in g.map(f) }
-}
-
-// MARK: - Contravariant Functor
-
-extension FunctionM {
-  public func contramap<B>(_ f: @escaping (B) -> A) -> FunctionM<B, M> {
-    return .init(f >>> self.call)
-  }
-
-  public static func >¢< <D, B, N>(f: @escaping (B) -> D, g: FunctionM<D, N>) -> FunctionM<B, N> {
-    return g.contramap(f)
-  }
-}
-
-public func contramap<D, B, N>(_ f: @escaping (B) -> D) -> (FunctionM<D, N>) -> FunctionM<B, N> {
-  return { g in g.contramap(f) }
-}
-
-// MARK: - Apply
-
-extension FunctionM {
-  public func ap<N>(_ f: FunctionM<A, FunctionM<M, N>>) -> FunctionM<A, N> {
-    return FunctionM<A, N>.init { a in
-      f.call(a).call(self.call(a))
-    }
-  }
-
-  public static func <*><A, M, N>(f: FunctionM<A, FunctionM<M, N>>, x: FunctionM<A, M>) -> FunctionM<A, N> {
-    return x.ap(f)
-  }
-}
-
-// MARK: - Applicative
-
-public func pure<A, M>(_ m: M) -> FunctionM<A, M> {
-  return FunctionM(const(m))
-}
-
-// MARK: - Monad
-
-extension FunctionM {
-  public func flatMap<N>(_ f: @escaping (M) -> FunctionM<A, N>) -> FunctionM<A, N> {
-    return FunctionM<A, N> { a in
-      return f(self.call(a)).call(a)
-    }
   }
 }

--- a/Sources/Prelude/FunctionProtocol.swift
+++ b/Sources/Prelude/FunctionProtocol.swift
@@ -1,0 +1,138 @@
+public protocol FunctionProtocol {
+  associatedtype Source
+  associatedtype Target
+  var call: (Source) -> Target { get }
+  init(_ call: @escaping (Source) -> Target)
+}
+
+public struct Function<A, B>: FunctionProtocol {
+  public typealias Source = A
+  public typealias Target = B
+
+  public let call: (A) -> B
+  public init(_ call: @escaping (A) -> B) {
+    self.call = call
+  }
+}
+
+// MARK: - Functor
+
+extension FunctionProtocol {
+  public func map<B, F: FunctionProtocol>(
+    _ f: @escaping (Target) -> B
+    )
+    -> F
+    where F.Source == Source, F.Target == B {
+
+      return .init(self.call >>> f)
+  }
+
+  public static func <¢> <C, G: FunctionProtocol>(
+    f: @escaping (Target) -> C,
+    g: Self
+    )
+    -> G
+    where G.Source == Source, G.Target == C {
+
+      return g.map(f)
+  }
+}
+
+public func map<A, B, C, F: FunctionProtocol, G: FunctionProtocol>(
+  _ f: @escaping (B) -> C
+  )
+  -> (F)
+  -> (G)
+  where F.Source == A, F.Target == B, G.Source == A, G.Target == C {
+
+    return { g in g.map(f) }
+}
+
+// MARK: - Contravariant Functor
+
+extension FunctionProtocol {
+  public func contramap<C, G: FunctionProtocol>(
+    _ f: @escaping (C) -> Source
+    )
+    -> G
+    where G.Source == C, G.Target == Target {
+
+      return .init(f >>> self.call)
+  }
+
+  public static func >¢< <C, G: FunctionProtocol>(
+    f: @escaping (C) -> Source
+    , g: Self
+    )
+    -> G
+    where G.Source == C, G.Target == Target {
+      return g.contramap(f)
+  }
+}
+
+public func contramap<A, B, C, F: FunctionProtocol, G: FunctionProtocol>(
+  _ f: @escaping (C) -> A
+  )
+  -> (F)
+  -> G
+  where F.Source == A, F.Target == B, G.Source == C, G.Target == B {
+    return { g in g.contramap(f) }
+}
+
+// MARK: - Apply
+
+extension FunctionProtocol {
+  public func ap<C, F: FunctionProtocol, G: FunctionProtocol>(_ f: F) -> G
+    where F.Source == Source,
+    F.Target: FunctionProtocol,
+    F.Target.Source == Target,
+    F.Target.Target == C,
+    G.Source == Source,
+    G.Target == C {
+
+      return .init { a in f.call(a).call(self.call(a)) }
+  }
+
+  public static func <*><C, F: FunctionProtocol, G: FunctionProtocol>(f: F, x: Self) -> G
+    where F.Source == Source,
+    F.Target: FunctionProtocol,
+    F.Target.Source == Target,
+    F.Target.Target == C,
+    G.Source == Source,
+    G.Target == C {
+
+      return x.ap(f)
+  }
+}
+
+// MARK: - Applicative
+
+public func pure<A, B, F: FunctionProtocol>(_ b: B) -> F
+  where F.Source == A, F.Target == B {
+    return .init(const(b))
+}
+
+// MARK: - Monad
+
+extension FunctionProtocol {
+  public func flatMap<C, F: FunctionProtocol>(_ f: @escaping (Target) -> F) -> F
+    where F.Source == Source, F.Target == C {
+      return .init { a in f(self.call(a)).call(a) }
+  }
+
+  public static func >>- <C, F: FunctionProtocol>(x: Self, f: @escaping (Target) -> F) -> F
+    where F.Source == Source, F.Target == C {
+
+      return x.flatMap(f)
+  }
+}
+
+public func >>> <A, B, C, F: FunctionProtocol, G: FunctionProtocol, H: FunctionProtocol>(f: F, g: G) -> H
+  where F.Source == A, F.Target == B, G.Source == B, G.Target == C, H.Source == A, H.Target == C {
+    return .init(f.call >>> g.call)
+}
+
+public func |> <A, B, F: FunctionProtocol> (a: A, f: F) -> B
+  where F.Source == A, F.Target == B {
+    return f.call(a)
+}

--- a/Sources/Prelude/FunctionProtocol.swift
+++ b/Sources/Prelude/FunctionProtocol.swift
@@ -5,16 +5,6 @@ public protocol FunctionProtocol {
   init(_ call: @escaping (Source) -> Target)
 }
 
-public struct Function<A, B>: FunctionProtocol {
-  public typealias Source = A
-  public typealias Target = B
-
-  public let call: (A) -> B
-  public init(_ call: @escaping (A) -> B) {
-    self.call = call
-  }
-}
-
 // MARK: - Functor
 
 extension FunctionProtocol {


### PR DESCRIPTION
I have a feeling we have a lot of function types in our future to overcome that swift doesn't treat `(A) -> B` as a first-class type. this will help us at least get a bunch of standard stuff for free anytime we need to create a new one...