### PR TITLE
Add Sequence-based apply

### DIFF
--- a/Prelude.playground/Contents.swift
+++ b/Prelude.playground/Contents.swift
@@ -1,6 +1,8 @@
 import Prelude
 
-let incr = { $0 + 1 }
+let add: (Int) -> (Int) -> Int = { x in { y in x + y } }
+let incr = add(1)
 let square: (Int) -> Int = { $0 * $0 }
 
 [incr, square] <*> [1, 2, 3]
+[add] <*> [1] <*> [2, 3]

--- a/Prelude.xcworkspace/contents.xcworkspacedata
+++ b/Prelude.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Prelude.xcodeproj">
+      location = "group:Prelude.playground">
    </FileRef>
    <FileRef
-      location = "group:Prelude.playground">
+      location = "group:Prelude.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Sources/Prelude/Array.swift
+++ b/Sources/Prelude/Array.swift
@@ -3,14 +3,6 @@ public func uncons<A>(_ xs: [A]) -> (A, [A])? {
   return (x, Array(xs.dropFirst()))
 }
 
-public func <*> <A, B> (fs: [(A) -> B], xs: [A]) -> [B] {
-  return fs.flatMap { f in xs.map(f) }
-}
-
-public func pure<A>(_ a: A) -> [A] {
-  return [a]
-}
-
 public func partition<A>(_ p: @escaping (A) -> Bool) -> ([A]) -> ([A], [A]) {
   return { xs in
     xs.reduce(([], [])) { accum, x in
@@ -35,4 +27,10 @@ public func lookup<A: Equatable, B>(_ x: A) -> ([(A, B)]) -> B? {
 
 public func replicate<A>(_ n: Int) -> (A) -> [A] {
   return { a in (1...n).map(const(a)) }
+}
+
+// MARK: - Applicative
+
+public func pure<A>(_ a: A) -> [A] {
+  return [a]
 }

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -1,13 +1,3 @@
-extension Sequence {
-  public static func <¢> <A>(f: (Element) -> A, xs: Self) -> [A] {
-    return xs.map(f)
-  }
-
-  public static func >>- <S: Sequence>(xs: Self, f: (Element) -> S) -> [S.Element] {
-    return xs.flatMap(f)
-  }
-}
-
 public func catOptionals<S: Sequence, A>(_ xs: S) -> [A] where S.Element == A? {
   return xs |> mapOptional(id)
 }
@@ -15,6 +5,20 @@ public func catOptionals<S: Sequence, A>(_ xs: S) -> [A] where S.Element == A? {
 public func mapOptional<S: Sequence, A>(_ f: @escaping (S.Element) -> A?) -> (S) -> [A] {
   return { xs in
     xs.flatMap(f)
+  }
+}
+
+// MARK: - Functor
+
+extension Sequence {
+  public static func <¢> <A>(f: (Element) -> A, xs: Self) -> [A] {
+    return xs.map(f)
+  }
+}
+
+public func map<S: Sequence, A>(_ f: @escaping (S.Element) -> A) -> (S) -> [A] {
+  return { xs in
+    return f <¢> xs
   }
 }
 
@@ -36,6 +40,20 @@ public func apply<S: Sequence, T: Sequence, A>(_ fs: S) -> (T) -> [A] where S.El
   }
 }
 
+// MARK: - Bind/Monad
+
+extension Sequence {
+  public static func >>- <S: Sequence>(xs: Self, f: (Element) -> S) -> [S.Element] {
+    return xs.flatMap(f)
+  }
+}
+
+public func flatMap<S: Sequence, A>(_ f: @escaping (S.Element) -> [A]) -> (S) -> [A] {
+  return { xs in
+    xs >>- f
+  }
+}
+
 // MARK: - Monoid
 
 extension Sequence where Element: Monoid {
@@ -44,7 +62,7 @@ extension Sequence where Element: Monoid {
   }
 }
 
-// MARK: - Foldable
+// MARK: - Foldable/Traversable
 
 public func foldMap<S: Sequence, M: Monoid>(_ f: @escaping (S.Element) -> M) -> (S) -> M {
   return { xs in

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -20,8 +20,20 @@ public func mapOptional<S: Sequence, A>(_ f: @escaping (S.Element) -> A?) -> (S)
 
 // MARK: - Apply
 
-public func <*> <S: Sequence, T: Sequence, A> (fs: S, xs: T) -> [A] where S.Element == ((T.Element) -> A) {
-  return fs.flatMap { f in xs.map { x in f(x) } }
+public extension Sequence {
+  public func apply<S: Sequence, A>(_ fs: S) -> [A] where S.Element == ((Element) -> A) {
+    return fs.flatMap { f in self.map { x in f(x) } }
+  }
+
+  public static func <*> <S: Sequence, A>(fs: S, xs: Self) -> [A] where S.Element == ((Element) -> A) {
+    return fs.flatMap { f in xs.map { x in f(x) } }
+  }
+}
+
+public func apply<S: Sequence, T: Sequence, A>(_ fs: S) -> (T) -> [A] where S.Element == ((T.Element) -> A) {
+  return { xs in
+    return fs.flatMap { f in xs.map { x in f(x) } }
+  }
 }
 
 // MARK: - Monoid

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -18,6 +18,12 @@ public func mapOptional<S: Sequence, A>(_ f: @escaping (S.Element) -> A?) -> (S)
   }
 }
 
+// MARK: - Apply
+
+public func <*> <S: Sequence, T: Sequence, A> (fs: S, xs: T) -> [A] where S.Element == ((T.Element) -> A) {
+  return fs.flatMap { f in xs.map { x in f(x) } }
+}
+
 // MARK: - Monoid
 
 extension Sequence where Element: Monoid {


### PR DESCRIPTION
Turns out our earlier issue was around some `throws`-based ambiguity. Going point-full allows us to add `<*>` to `Sequence`. Compiler gets real confused here with the implementations, but actual use seems to work well enough.