### PR TITLE
Rename/reorganize around Monoid

### DIFF
--- a/Sources/Prelude/FunctionM.swift
+++ b/Sources/Prelude/FunctionM.swift
@@ -19,8 +19,8 @@ extension FunctionM: Semigroup {
 // MARK: - Monoid
 
 extension FunctionM: Monoid {
-  public static var e: FunctionM {
-    return FunctionM(const(M.e))
+  public static var empty: FunctionM {
+    return FunctionM(const(M.empty))
   }
 }
 

--- a/Sources/Prelude/Monoid.swift
+++ b/Sources/Prelude/Monoid.swift
@@ -1,17 +1,13 @@
 public protocol Monoid: Semigroup {
-  static var e: Self { get }
-}
-
-public func concat<S: Sequence>(_ xs: S) -> S.Element where S.Element: Monoid {
-  return xs.reduce(S.Element.e, <>)
+  static var empty: Self { get }
 }
 
 extension String: Monoid {
-  public static let e = ""
+  public static let empty = ""
 }
 
 extension Array: Monoid {
-  public static var e: Array { return [] }
+  public static var empty: Array { return [] }
 }
 
 public func joined<M: Monoid>(_ s: M) -> ([M]) -> M {
@@ -19,6 +15,6 @@ public func joined<M: Monoid>(_ s: M) -> ([M]) -> M {
     if let head = xs.first {
       return xs.dropFirst().reduce(head) { accum, x in accum <> s <> x }
     }
-    return .e
+    return .empty
   }
 }

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -26,11 +26,21 @@ extension Sequence where Element: Monoid {
   }
 }
 
+public func concat<S: Sequence>(_ xs: S) -> S.Element where S.Element: Monoid {
+  return xs.concat()
+}
+
 // MARK: - Foldable
+
+extension Sequence {
+  public func foldMap<M: Monoid>(_ f: @escaping (Element) -> M) -> M {
+    return self.reduce(M.empty) { m, x in m <> f(x) }
+  }
+}
 
 public func foldMap<S: Sequence, M: Monoid>(_ f: @escaping (S.Element) -> M) -> (S) -> M {
   return { xs in
-    xs.reduce(M.e) { accum, x in accum <> f(x) }
+    xs.foldMap(f)
   }
 }
 

--- a/Sources/Prelude/Tuple.swift
+++ b/Sources/Prelude/Tuple.swift
@@ -5,3 +5,25 @@ public func first<A, B>(_ x: (A, B)) -> A {
 public func second<A, B>(_ x: (A, B)) -> B {
   return x.1
 }
+
+// MARK: - Semigroupoid
+
+public func >>> <A, B, C>(_ ab: (A, B), _ bc: (B, C)) -> (A, C) {
+  return (ab.0, bc.1)
+}
+
+public func <<< <A, B, C>(_ bc: (B, C), _ ab: (A, B)) -> (A, C) {
+  return (ab.0, bc.1)
+}
+
+// MARK: - Semigroup
+
+public func <> <A: Semigroup, B: Semigroup>(_ ab1: (A, B), _ ab2: (A, B)) -> (A, B) {
+  return (ab1.0 <> ab2.0, ab1.1 <> ab2.1)
+}
+
+// MARK: - Monoid
+
+public func empty<A: Monoid, B: Monoid>() -> (A, B) {
+  return (A.empty, B.empty)
+}


### PR DESCRIPTION
Alright I know `e` is kinda a nice abstraction from `empty`, but a few nice things about renaming:

- Parity with PureScript
- Overlap with "Plus" (which is the monoidal identity of functorial "Alternative")
- When we write free functions, it's more descriptive