### PR TITLE
Add IO.wrap

### DIFF
--- a/Sources/Prelude/IO.swift
+++ b/Sources/Prelude/IO.swift
@@ -16,6 +16,12 @@ extension IO {
       .init { f(input) }
     }
   }
+
+  public static func wrap(_ f: @escaping () -> A) -> () -> IO<A> {
+    return {
+      .init { f() }
+    }
+  }
 }
 
 // MARK: - Functor

--- a/Sources/Prelude/IO.swift
+++ b/Sources/Prelude/IO.swift
@@ -10,6 +10,14 @@ public struct IO<A> {
   }
 }
 
+extension IO {
+  public static func wrap<I>(_ f: @escaping (I) -> A) -> (I) -> IO<A> {
+    return { input in
+      .init { f(input) }
+    }
+  }
+}
+
 // MARK: - Functor
 
 extension IO {


### PR DESCRIPTION
Not sure if this should be called something else (`liftIO` seems to mean something different—monad transformers and all), but it's a handy utility function for controlling effects in a language of uncontrolled effects.

A basic example:

``` swift
let printLn = IO.wrap { print($0) }
let io = printLn("Hello, world!")   // delayed IO<()> action
io.perform()                        // prints "Hello, world!"

// point-freeeee
IO.wrap(arc4random)                 // () -> IO<UInt32>
IO.wrap(arc4random_uniform)         // (UInt32) -> IO<UInt32>
```