### PR TITLE
Fixed recursive call to concat

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,8 @@
+{
+  "object": {
+    "pins": [
+
+    ]
+  },
+  "version": 1
+}

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -63,7 +63,7 @@ extension Sequence where Element: Monoid {
 }
 
 public func concat<S: Sequence>(_ xs: S) -> S.Element where S.Element: Monoid {
-  return xs.concat()
+  return xs.reduce(.empty, <>)
 }
 
 // MARK: - Foldable/Traversable

--- a/Tests/PreludeTests/SequenceTests.swift
+++ b/Tests/PreludeTests/SequenceTests.swift
@@ -9,4 +9,8 @@ class SequenceTests: XCTestCase {
   func testMapOptional() {
     XCTAssertEqual([2], [1, 2, 3] |> mapOptional { $0 % 2 == 0 ? $0 : nil })
   }
+
+  func testConcat() {
+    XCTAssertEqual("foobar", ["foo", "bar"].concat())
+  }
 }


### PR DESCRIPTION
We had two `concat` functions calling each other, which eventually crashed! this fixes it...