### PR TITLE
Add Either.wrap

### DIFF
--- a/Sources/Either/Either.swift
+++ b/Sources/Either/Either.swift
@@ -6,10 +6,10 @@ public enum Either<L, R> {
 }
 
 extension Either {
-  public func either<A>(_ l2a: (L) -> A, _ r2a: (R) -> A) -> A {
+  public func either<A>(_ l2a: (L) throws -> A, _ r2a: (R) -> A) rethrows -> A {
     switch self {
     case let .left(l):
-      return l2a(l)
+      return try l2a(l)
     case let .right(r):
       return r2a(r)
     }
@@ -29,28 +29,6 @@ extension Either {
 
   public var isRight: Bool {
     return either(const(false), const(true))
-  }
-}
-
-public extension Either where L == Error {
-  public static func wrap<A>(_ f: @escaping (A) throws -> R) -> (A) -> Either {
-    return { a in
-      do {
-        return .right(try f(a))
-      } catch let error {
-        return .left(error)
-      }
-    }
-  }
-
-  public static func wrap(_ f: @escaping () throws -> R) -> () -> Either {
-    return {
-      do {
-        return .right(try f())
-      } catch let error {
-        return .left(error)
-      }
-    }
   }
 }
 
@@ -76,6 +54,36 @@ public func note<L, R>(_ default: L) -> (R?) -> Either<L, R> {
 
 public func hush<L, R>(_ lr: Either<L, R>) -> R? {
   return lr.either(const(.none), R?.some)
+}
+
+public extension Either where L == Error {
+  public static func wrap<A>(_ f: @escaping (A) throws -> R) -> (A) -> Either {
+    return { a in
+      do {
+        return .right(try f(a))
+      } catch let error {
+        return .left(error)
+      }
+    }
+  }
+
+  public static func wrap(_ f: @escaping () throws -> R) -> () -> Either {
+    return {
+      do {
+        return .right(try f())
+      } catch let error {
+        return .left(error)
+      }
+    }
+  }
+
+  public func unwrap() throws -> R {
+    return try either({ throw $0 }, id)
+  }
+}
+
+public func unwrap<L: Error, R>(_ either: Either<L, R>) throws -> R {
+  return try unwrap(either)
 }
 
 // MARK: - Functor

--- a/Sources/Either/Either.swift
+++ b/Sources/Either/Either.swift
@@ -32,6 +32,28 @@ extension Either {
   }
 }
 
+public extension Either where L == Error {
+  public static func wrap<A>(_ f: @escaping (A) throws -> R) -> (A) -> Either {
+    return { a in
+      do {
+        return .right(try f(a))
+      } catch let error {
+        return .left(error)
+      }
+    }
+  }
+
+  public static func wrap(_ f: @escaping () throws -> R) -> () -> Either {
+    return {
+      do {
+        return .right(try f())
+      } catch let error {
+        return .left(error)
+      }
+    }
+  }
+}
+
 public func either<A, B, C>(_ a2c: @escaping (A) -> C) -> (@escaping (B) -> C) -> (Either<A, B>) -> C {
   return { b2c in
     { ab in

--- a/Tests/EitherTests/EitherTests.swift
+++ b/Tests/EitherTests/EitherTests.swift
@@ -45,6 +45,23 @@ class EitherTests: XCTestCase {
     XCTAssertEqual("Oops!", (Either.wrap(bar)().left as? WrapError)?.message)
   }
 
+  func testUnwrap() {
+    struct WrapError: Error {
+      let message: String
+    }
+
+    func foo() throws -> Int {
+      return 1
+    }
+
+    func bar() throws -> Int {
+      throw WrapError(message: "Oops!")
+    }
+
+    XCTAssertEqual(1, try Either.wrap(foo)().unwrap())
+    XCTAssertThrowsError(try Either.wrap(bar)().unwrap())
+  }
+
   func testMap() {
     XCTAssertEqual(2, (Either<Int, Int>.right(1) |> map { $0 + 1 }).right)
     XCTAssertEqual(1, (Either<Int, Int>.left(1) |> map { $0 + 1 }).left)

--- a/Tests/EitherTests/EitherTests.swift
+++ b/Tests/EitherTests/EitherTests.swift
@@ -28,6 +28,23 @@ class EitherTests: XCTestCase {
     XCTAssertTrue(Either<String, Int>.right(5).isRight)
   }
 
+  func testWrap() {
+    struct WrapError: Error {
+      let message: String
+    }
+
+    func foo() throws -> Int {
+      return 1
+    }
+
+    func bar() throws -> Int {
+      throw WrapError(message: "Oops!")
+    }
+
+    XCTAssertEqual(1, Either.wrap(foo)().right)
+    XCTAssertEqual("Oops!", (Either.wrap(bar)().left as? WrapError)?.message)
+  }
+
   func testMap() {
     XCTAssertEqual(2, (Either<Int, Int>.right(1) |> map { $0 + 1 }).right)
     XCTAssertEqual(1, (Either<Int, Int>.left(1) |> map { $0 + 1 }).left)


### PR DESCRIPTION
This PR may expand, but so far includes some nice utility methods to bridge `throws` with `Either`.

``` swift
let removeItemAtPath = FileManager.default.removeItem(atPath:)
  |> Either.wrap >>> IO.wrap

// (String) -> IO<Either<Error, ()>>
```