### PR TITLE
Additions around `throws` interoperability

### DIFF
--- a/Sources/Either/Either.swift
+++ b/Sources/Either/Either.swift
@@ -32,11 +32,9 @@ extension Either {
   }
 }
 
-public func either<A, B, C>(_ a2c: @escaping (A) -> C) -> (@escaping (B) -> C) -> (Either<A, B>) -> C {
-  return { b2c in
-    { ab in
-      ab.either(a2c, b2c)
-    }
+public func either<A, B, C>(_ a2c: @escaping (A) -> C, _ b2c: @escaping (B) -> C) -> (Either<A, B>) -> C {
+  return { ab in
+    ab.either(a2c, b2c)
   }
 }
 
@@ -82,8 +80,18 @@ public extension Either where L == Error {
   }
 }
 
+public extension Either where L: Error {
+  public func unwrap() throws -> R {
+    return try either({ throw $0 }, id)
+  }
+}
+
+public func unwrap<R>(_ either: Either<Error, R>) throws -> R {
+  return try either.unwrap()
+}
+
 public func unwrap<L: Error, R>(_ either: Either<L, R>) throws -> R {
-  return try unwrap(either)
+  return try either.unwrap()
 }
 
 // MARK: - Functor
@@ -122,14 +130,11 @@ extension Either {
   }
 }
 
-public func bimap<A, B, C, D>(_ a2b: @escaping (A) -> B)
-  -> (@escaping (C) -> D)
+public func bimap<A, B, C, D>(_ a2b: @escaping (A) -> B, _ c2d: @escaping (C) -> D)
   -> (Either<A, C>)
   -> Either<B, D> {
-    return { c2d in
-      { ac in
-        ac.bimap(a2b, c2d)
-      }
+    return { ac in
+      ac.bimap(a2b, c2d)
     }
 }
 

--- a/Sources/Prelude/Function.swift
+++ b/Sources/Prelude/Function.swift
@@ -14,12 +14,12 @@ public func const<A, B>(_ a: A) -> (B) -> A {
   return { _ in a }
 }
 
-public func <| <A, B> (f: (A) -> B, a: A) -> B {
-  return f(a)
+public func <| <A, B> (f: (A) throws -> B, a: A) rethrows -> B {
+  return try f(a)
 }
 
-public func |> <A, B> (a: A, f: (A) -> B) -> B {
-  return f(a)
+public func |> <A, B> (a: A, f: (A) throws -> B) rethrows -> B {
+  return try f(a)
 }
 
 public func uncurry<A, B, C>(_ f: @escaping (A) -> (B) -> C) -> (A, B) -> C {


### PR DESCRIPTION
Hit a few snags when performing unsafe IO and unwrapping Eithers.