### PR TITLE
Add indexed dictionary optics

### DIFF
--- a/Sources/Optics/Index.swift
+++ b/Sources/Optics/Index.swift
@@ -1,16 +1,38 @@
+// MARK: - Getter
+
 public func ix<C: Collection>(_ idx: C.Index) -> Getter<C, C, C.Element, C.Element> {
-  return { (forget: Forget<C.Element, C.Element, C.Element>) -> Forget<C.Element, C, C> in
-    Forget<C.Element, C, C> { (xs: C) -> C.Element in
+  return { forget in
+    .init { xs in
       forget.unwrap(xs[idx])
     }
   }
 }
+
+public func key<K: Hashable, V>(_ key: K) -> Getter<[K: V], [K: V], V?, V?> {
+  return { forget in
+    .init { dict in
+      forget.unwrap(dict[key])
+    }
+  }
+}
+
+// MARK: - Setter
 
 public func ix<C: MutableCollection>(_ idx: C.Index) -> Setter<C, C, C.Element, C.Element> {
   return { f in
     { xs in
       var copy = xs
       copy[idx] = f(copy[idx])
+      return copy
+    }
+  }
+}
+
+public func key<K: Hashable, V>(_ key: K) -> Setter<[K: V], [K: V], V?, V?> {
+  return { f in
+    { dict in
+      var copy = dict
+      copy[key] = f(copy[key])
       return copy
     }
   }

--- a/Sources/Optics/Index.swift
+++ b/Sources/Optics/Index.swift
@@ -16,6 +16,14 @@ public func key<K: Hashable, V>(_ key: K) -> Getter<[K: V], [K: V], V?, V?> {
   }
 }
 
+public func elem<A: Hashable>(_ elem: A) -> Getter<Set<A>, Set<A>, Bool, Bool> {
+  return { forget in
+    .init { set in
+      forget.unwrap(set.contains(elem))
+    }
+  }
+}
+
 // MARK: - Setter
 
 public func ix<C: MutableCollection>(_ idx: C.Index) -> Setter<C, C, C.Element, C.Element> {
@@ -33,6 +41,20 @@ public func key<K: Hashable, V>(_ key: K) -> Setter<[K: V], [K: V], V?, V?> {
     { dict in
       var copy = dict
       copy[key] = f(copy[key])
+      return copy
+    }
+  }
+}
+
+public func elem<A: Hashable>(_ elem: A) -> Setter<Set<A>, Set<A>, Bool, Bool> {
+  return { f in
+    { set in
+      var copy = set
+      if f(copy.contains(elem)) {
+        copy.insert(elem)
+      } else {
+        copy.remove(elem)
+      }
       return copy
     }
   }

--- a/Tests/OpticsTests/OpticsTests.swift
+++ b/Tests/OpticsTests/OpticsTests.swift
@@ -54,12 +54,14 @@ class PreludeTests: XCTestCase {
   }
 
   func testElem() {
-    XCTAssertEqual(true, Set<Int>(arrayLiteral: 1, 2, 3) .^ elem(3))
-    XCTAssertEqual(false, Set<Int>(arrayLiteral: 1, 2, 3) .^ elem(4))
+    let set: Set<Int> = [1, 2, 3]
 
-    XCTAssertEqual([1, 2], Set<Int>(arrayLiteral: 1, 2, 3) |> elem(3) .~ false)
-    XCTAssertEqual([1, 2, 3, 4], Set<Int>(arrayLiteral: 1, 2, 3) |> elem(4) .~ true)
-    XCTAssertEqual([1, 2, 3, 5], Set<Int>(arrayLiteral: 1, 2, 3) |> elem(5) %~ { !$0 })
+    XCTAssertEqual(true, set .^ elem(3))
+    XCTAssertEqual(false, set .^ elem(4))
+
+    XCTAssertEqual([1, 2], set |> elem(3) .~ false)
+    XCTAssertEqual([1, 2, 3, 4], set |> elem(4) .~ true)
+    XCTAssertEqual([1, 2, 3, 5], set |> elem(5) %~ { !$0 })
   }
 
   func testOver() {

--- a/Tests/OpticsTests/OpticsTests.swift
+++ b/Tests/OpticsTests/OpticsTests.swift
@@ -50,7 +50,7 @@ class PreludeTests: XCTestCase {
     XCTAssertNil(["a": 999] .^ key("b"))
 
     XCTAssertEqual(["a": 1000], ["a": 999] |> key("a") <<< traversed +~ 1)
-    XCTAssertEqual(["a": 999, "b": 1], ["a": 999] |> key("b") %~ { $0 ?? 0 + 1 })
+    XCTAssertEqual(["a": 999, "b": 1], ["a": 999] |> key("b") %~ { ($0 ?? 0) + 1 })
   }
 
   func testOver() {

--- a/Tests/OpticsTests/OpticsTests.swift
+++ b/Tests/OpticsTests/OpticsTests.swift
@@ -45,6 +45,14 @@ class PreludeTests: XCTestCase {
     assertSnapshot(matching: episode |> \.guests <<< ix(1) <<< \.name .~ "Pleb")
   }
 
+  func testKey() {
+    XCTAssertEqual(.some(999), ["a": 999] .^ key("a"))
+    XCTAssertNil(["a": 999] .^ key("b"))
+
+    XCTAssertEqual(["a": 1000], ["a": 999] |> key("a") <<< traversed +~ 1)
+    XCTAssertEqual(["a": 999, "b": 1], ["a": 999] |> key("b") %~ { $0 ?? 0 + 1 })
+  }
+
   func testOver() {
     assertSnapshot(matching: episode |> \.host.name %~ uppercased)
   }

--- a/Tests/OpticsTests/OpticsTests.swift
+++ b/Tests/OpticsTests/OpticsTests.swift
@@ -53,6 +53,15 @@ class PreludeTests: XCTestCase {
     XCTAssertEqual(["a": 999, "b": 1], ["a": 999] |> key("b") %~ { ($0 ?? 0) + 1 })
   }
 
+  func testElem() {
+    XCTAssertEqual(true, Set<Int>(arrayLiteral: 1, 2, 3) .^ elem(3))
+    XCTAssertEqual(false, Set<Int>(arrayLiteral: 1, 2, 3) .^ elem(4))
+
+    XCTAssertEqual([1, 2], Set<Int>(arrayLiteral: 1, 2, 3) |> elem(3) .~ false)
+    XCTAssertEqual([1, 2, 3, 4], Set<Int>(arrayLiteral: 1, 2, 3) |> elem(4) .~ true)
+    XCTAssertEqual([1, 2, 3, 5], Set<Int>(arrayLiteral: 1, 2, 3) |> elem(5) %~ { !$0 })
+  }
+
   func testOver() {
     assertSnapshot(matching: episode |> \.host.name %~ uppercased)
   }


### PR DESCRIPTION
Just some quick work around indexed dictionary optics.

``` swift
["a": 999] |> key("a") <<< traversed +~ 1
// ["a": 1000]

["a": 999] |> key("b") %~ { ($0 ?? 0) + 1 }
// ["a": 999, "b": 1]
```