### PR TITLE
Added do an intersperse.

### DIFF
--- a/Sources/Prelude/Optional.swift
+++ b/Sources/Prelude/Optional.swift
@@ -10,6 +10,13 @@ public func coalesce<A>(with default: A) -> (A?) -> A {
   return optional(`default`) <| id
 }
 
+
+extension Optional {
+  public func `do`(_ f: (Wrapped) -> Void) {
+    if let x = self { f(x) }
+  }
+}
+
 // MARK: - Functor
 
 extension Optional {

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -193,3 +193,15 @@ public func zipWith<S: Sequence, T: Sequence, A>(_ f: @escaping (S.Element, T.El
       }
     }
 }
+
+public func intersperse<A>(_ a: A) -> ([A]) -> [A] {
+  return { xs in
+    var result = [A]()
+    for x in xs.dropLast() {
+      result.append(x)
+      result.append(a)
+    }
+    xs.last.do { result.append($0) }
+    return result
+  }
+}

--- a/Tests/PreludeTests/SequenceTests.swift
+++ b/Tests/PreludeTests/SequenceTests.swift
@@ -13,4 +13,10 @@ class SequenceTests: XCTestCase {
   func testConcat() {
     XCTAssertEqual("foobar", ["foo", "bar"].concat())
   }
+
+  func testIntersperse() {
+    XCTAssertEqual([1, 0, 2, 0, 3], intersperse(0)([1, 2, 3]))
+    XCTAssertEqual([1], intersperse(0)([1]))
+    XCTAssertEqual([], intersperse(0)([]))
+  }
 }


### PR DESCRIPTION
looks like we are allowed to use `do` as a method name, so we can do `optionalValue.do(sideEffect)`.

also added `intersperse` cause I need it for something else I'm doing, and was the impetus of why I needed `do`.