### PR TITLE
Autoclosure and public init

### DIFF
--- a/Sources/Either/Either.swift
+++ b/Sources/Either/Either.swift
@@ -165,7 +165,7 @@ public func pure<L, R>(_ r: R) -> Either<L, R> {
 // MARK: - Alt
 
 extension Either: Alt {
-  public static func <|>(lhs: Either, rhs: @autoclosure () -> Either) -> Either {
+  public static func <|>(lhs: Either, rhs: @autoclosure @escaping () -> Either) -> Either {
     switch lhs {
     case .left:
       return rhs()

--- a/Sources/Either/Either.swift
+++ b/Sources/Either/Either.swift
@@ -164,11 +164,11 @@ public func pure<L, R>(_ r: R) -> Either<L, R> {
 
 // MARK: - Alt
 
-public func <|> <L, R>(lhs: Either<L, R>, rhs: Either<L, R>) -> Either<L, R> {
-  switch (lhs, rhs) {
-  case (.left, .right):
-    return rhs
-  default:
+public func <|> <L, R>(lhs: Either<L, R>, rhs: @autoclosure () -> Either<L, R>) -> Either<L, R> {
+  switch lhs {
+  case .left:
+    return rhs()
+  case .right:
     return lhs
   }
 }

--- a/Sources/Either/EitherIO.swift
+++ b/Sources/Either/EitherIO.swift
@@ -3,6 +3,10 @@ import Prelude
 /// A monad transformer (like `ExceptT`) for `IO` and `Either`.
 public struct EitherIO<E, A> {
   public let run: IO<Either<E, A>>
+
+  public init(run: IO<Either<E, A>>) {
+    self.run = run
+  }
 }
 
 public func lift<E, A>(_ x: Either<E, A>) -> EitherIO<E, A> {

--- a/Sources/Either/EitherIO.swift
+++ b/Sources/Either/EitherIO.swift
@@ -70,8 +70,8 @@ public func pure<E, A>(_ x: (A)) -> EitherIO<E, A> {
 // MARK: - Alt
 
 extension EitherIO: Alt {
-  public static func <|>(lhs: EitherIO, rhs: EitherIO) -> EitherIO {
-    return .init(run: .init { lhs.run.perform() <|> rhs.run.perform() })
+  public static func <|>(lhs: EitherIO, rhs: @autoclosure @escaping () -> EitherIO) -> EitherIO {
+    return .init(run: .init { lhs.run.perform() <|> rhs().run.perform() })
   }
 }
 

--- a/Sources/Frp/Event.swift
+++ b/Sources/Frp/Event.swift
@@ -198,8 +198,8 @@ public func pure<A>(_ a: A) -> Event<A> {
 // MARK: - Alt
 
 extension Event: Alt {
-  public static func <|>(lhs: Event, rhs: Event) -> Event {
-    return .merge(lhs, rhs)
+  public static func <|>(lhs: Event, rhs: @autoclosure @escaping () -> Event) -> Event {
+    return .merge(lhs, rhs())
   }
 }
 

--- a/Sources/Prelude/Alt.swift
+++ b/Sources/Prelude/Alt.swift
@@ -1,15 +1,15 @@
 public protocol Alt {
-  static func <|>(lhs: Self, rhs: Self) -> Self
+  static func <|>(lhs: Self, rhs: @autoclosure @escaping () -> Self) -> Self
 }
 
 extension Array: Alt {
-  public static func <|>(lhs: Array, rhs: Array) -> Array {
-    return lhs + rhs
+  public static func <|>(lhs: Array, rhs: @autoclosure @escaping () -> Array) -> Array {
+    return lhs + rhs()
   }
 }
 
 extension Optional: Alt {
-  public static func <|>(lhs: Optional, rhs: Optional) -> Optional {
-    return lhs ?? rhs
+  public static func <|>(lhs: Optional, rhs: @autoclosure @escaping () -> Optional) -> Optional {
+    return lhs ?? rhs()
   }
 }

--- a/Tests/EitherTests/EitherTests.swift
+++ b/Tests/EitherTests/EitherTests.swift
@@ -77,7 +77,7 @@ class EitherTests: XCTestCase {
 
   func testAlt() {
     XCTAssertEqual(2, (Either<String, Int>.left("Error") <|> Either<String, Int>.right(2)).right)
-    XCTAssertEqual("1", (Either<String, Int>.left("1") <|> Either<String, Int>.left("2")).left)
+    XCTAssertEqual("2", (Either<String, Int>.left("1") <|> Either<String, Int>.left("2")).left)
     XCTAssertEqual(1, (Either<String, Int>.right(1) <|> Either<String, Int>.right(2)).right)
     XCTAssertEqual(1, (Either<String, Int>.right(1) <|> Either<String, Int>.left("Error")).right)
   }

--- a/Tests/PreludeTests/ParallelTests.swift
+++ b/Tests/PreludeTests/ParallelTests.swift
@@ -4,15 +4,15 @@ import Prelude
 class ParallelTests: XCTestCase {
   func testParallel() {
     let add: (Int) -> (Int) -> Int = { x in { y in x + y } }
-    let x = pure(1).delay(0.01)
-    let y = pure(2).delay(0.01)
+    let x = pure(1).delay(0.1)
+    let y = pure(2).delay(0.1)
 
     XCTAssertEqual(3, (sequential <| add <¢> parallel(x) <*> parallel(y)).perform())
   }
 
   func testRace() {
-    let x = pure("tortoise").delay(0.01)
-    let y = pure("hare").delay(0.02)
+    let x = pure("tortoise").delay(0.1)
+    let y = pure("hare").delay(0.2)
 
     XCTAssertEqual("tortoise", (sequential <| parallel(x) <|> parallel(y)).perform())
     XCTAssertEqual("tortoise", (sequential <| parallel(y) <|> parallel(x)).perform())


### PR DESCRIPTION
We need to use an autoclosure in `<|>` for `Either` in order to get the types of short circuiting we expect when using `IO`. this is all I needed for my work, but we may want to also add to `EitherIO`? or maybe it isn't necessary there since it wraps an `IO`.