### PR TITLE
Support more curry args

### DIFF
--- a/Sources/Prelude/Curry.swift
+++ b/Sources/Prelude/Curry.swift
@@ -1,19 +1,63 @@
-public func curry<A, B, C>(_ f: @escaping (A, B) -> C) -> (A) -> (B) -> C {
-  return { a in
-    { b in
-      f(a, b)
-    }
-  }
-}
-
-public func curry<A, B, C, D>(_ f: @escaping (A, B, C) -> D) -> (A) -> (B) -> (C) -> D {
-  return { a in
-    { b in
-      { c in
-        f(a, b, c)
+public func curry<A, B, C>(_ f: @escaping (A, B) -> C)
+  -> (A)
+  -> (B)
+  -> C {
+    return { a in
+      { b in
+        f(a, b)
       }
     }
-  }
+}
+
+public func curry<A, B, C, D>(_ f: @escaping (A, B, C) -> D)
+  -> (A)
+  -> (B)
+  -> (C)
+  -> D {
+    return { a in
+      { b in
+        { c in
+          f(a, b, c)
+        }
+      }
+    }
+}
+
+public func curry<A, B, C, D, E>(_ f: @escaping (A, B, C, D) -> E)
+  -> (A)
+  -> (B)
+  -> (C)
+  -> (D)
+  -> E {
+    return { a in
+      { b in
+        { c in
+          { d in
+            f(a, b, c, d)
+          }
+        }
+      }
+    }
+}
+
+public func curry<A, B, C, D, E, F>(_ f: @escaping (A, B, C, D, E) -> F)
+  -> (A)
+  -> (B)
+  -> (C)
+  -> (D)
+  -> (E)
+  -> (F) {
+    return { a in
+      { b in
+        { c in
+          { d in
+            { e in
+              f(a, b, c, d, e)
+            }
+          }
+        }
+      }
+    }
 }
 
 public func uncurry<A, B, C>(_ f: @escaping (A) -> (B) -> C) -> (A, B) -> C {


### PR DESCRIPTION
Models in the code base are getting bigger, so the question is do we maintain curry internally (one-time cost), or lock to Thoughtbot's implementation? The only issue with Thoughtbot's is it'd be an external dependency and it does seem to have lagged in SPM and Swift version support (which may not be an issue).