### PR TITLE
Add "popLast" to NonEmptyArray

### DIFF
--- a/Sources/NonEmpty/Array.swift
+++ b/Sources/NonEmpty/Array.swift
@@ -32,6 +32,12 @@ public struct NonEmptyArray<A>: MutableNonEmpty {
   public mutating func append(_ newElement: A) {
     self.tail.append(newElement)
   }
+
+  /// - returns: The last element of the collection if it can be removed safely or `nil` if the collection is
+  ///   a singleton.
+  public mutating func popLast() -> A? {
+    return self.tail.popLast()
+  }
 }
 
 public func >| <A>(head: A, tail: [A]) -> NonEmptyArray<A> {

--- a/Tests/NonEmptyTests/NonEmptyTests.swift
+++ b/Tests/NonEmptyTests/NonEmptyTests.swift
@@ -47,6 +47,13 @@ final class NonEmptyTests: XCTestCase {
     XCTAssert((1 >| [2, 3, 4]) == nonEmpty)
   }
 
+  func testMutablePopLast() {
+    var nonEmpty = 1 >| [2]
+    XCTAssertEqual(.some(2), nonEmpty.popLast())
+    XCTAssertNil(nonEmpty.popLast())
+    XCTAssert((1 >| []) == nonEmpty)
+  }
+
   func testSet() {
     let nonEmpty = 1 >| Set([1, 2, 3])
     XCTAssertEqual(3, nonEmpty.count)


### PR DESCRIPTION
We have a common push/pop pattern for our environment of coeffects, but we use an array which should be non-empty. This PR adds a `popLast` method to non-empty arrays so that we can model our environment stack, at compile time, as something that always contains at least one environment.