### PR TITLE
Add prefix ^ to convert key paths to getters

### DIFF
--- a/Sources/Prelude/KeyPath.swift
+++ b/Sources/Prelude/KeyPath.swift
@@ -21,3 +21,11 @@ public func over<Root, Value>(_ keyPath: WritableKeyPath<Root, Value>)
 public func set<Root, Value>(_ keyPath: WritableKeyPath<Root, Value>) -> (Value) -> (Root) -> Root {
   return over(keyPath) <<< const
 }
+
+prefix operator ^
+
+extension KeyPath {
+  public static prefix func ^ (rhs: KeyPath) -> (Root) -> Value {
+    return get(rhs)
+  }
+}


### PR DESCRIPTION
Allows for some fun stuff and looks like our getter operator!

``` swift
["Hello", "world"].map(^\.count)
```