### PR TITLE
Add Semigroup/Monoid instance of Dictionary

### DIFF
--- a/Sources/Prelude/Monoid.swift
+++ b/Sources/Prelude/Monoid.swift
@@ -2,12 +2,16 @@ public protocol Monoid: Semigroup {
   static var empty: Self { get }
 }
 
-extension String: Monoid {
-  public static let empty = ""
-}
-
 extension Array: Monoid {
   public static var empty: Array { return [] }
+}
+
+extension Dictionary: Monoid {
+  public static var empty: Dictionary { return [:] }
+}
+
+extension String: Monoid {
+  public static let empty = ""
 }
 
 public func joined<M: Monoid>(_ s: M) -> ([M]) -> M {

--- a/Sources/Prelude/Semigroup.swift
+++ b/Sources/Prelude/Semigroup.swift
@@ -14,14 +14,20 @@ public func concat<S: Sequence>(_ xs: S, _ e: S.Element) -> S.Element where S.El
   return xs.reduce(e, <>)
 }
 
-extension String: Semigroup {
-  public static func <>(lhs: String, rhs: String) -> String {
+extension Array: Semigroup {
+  public static func <>(lhs: Array, rhs: Array) -> Array {
     return lhs + rhs
   }
 }
 
-extension Array: Semigroup {
-  public static func <>(lhs: Array, rhs: Array) -> Array {
+extension Dictionary: Semigroup {
+  public static func <>(lhs: Dictionary, rhs: Dictionary) -> Dictionary {
+    return lhs.merging(rhs, uniquingKeysWith: { $1 })
+  }
+}
+
+extension String: Semigroup {
+  public static func <>(lhs: String, rhs: String) -> String {
     return lhs + rhs
   }
 }


### PR DESCRIPTION
From https://github.com/pointfreeco/pointfreeco-server/blob/1074281c9a3dc9d3230871a6ed053e14458efbbb/Sources/pointfreeco/main.swift#L38

Dictionary's a strange one because, when you have conditional conformance, would you want to also support this?

``` swift
extension Dictionary: Semigroup where Value: Semigroup {
  public static func <>(lhs: Dictionary, rhs: Dictionary) -> Dictionary {
    return lhs.merging(rhs, uniquingKeysWith: <>)
  }
}
```

Maybe both will work just fine in the end?