### PR TITLE
Make tuple fields `var`s

### DIFF
--- a/Prelude.playground/Pages/Tuple.xcplaygroundpage/Contents.swift
+++ b/Prelude.playground/Pages/Tuple.xcplaygroundpage/Contents.swift
@@ -1,0 +1,10 @@
+import Tuple
+import Optics
+import Prelude
+
+let tuple = 1 .*. "hello" .*. true
+
+tuple
+  |> \.second.first %~ { "\($0)!" }
+
+print("✅")

--- a/Prelude.playground/Pages/Tuple.xcplaygroundpage/Contents.swift
+++ b/Prelude.playground/Pages/Tuple.xcplaygroundpage/Contents.swift
@@ -1,6 +1,6 @@
-import Tuple
 import Optics
 import Prelude
+import Tuple
 
 let tuple = 1 .*. "hello" .*. true
 

--- a/Prelude.playground/Pages/Tuple.xcplaygroundpage/Contents.swift
+++ b/Prelude.playground/Pages/Tuple.xcplaygroundpage/Contents.swift
@@ -5,6 +5,8 @@ import Prelude
 let tuple = 1 .*. "hello" .*. true
 
 tuple
-  |> \.second.first %~ { "\($0)!" }
+  |> \.first .~ 2
+  |> \.second.first .~ "Hello!"
+  |> \.second.second.first .~ false
 
 print("✅")

--- a/Prelude.playground/contents.xcplayground
+++ b/Prelude.playground/contents.xcplayground
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos'>
+<playground version='6.0' target-platform='macos' executeOnSourceChanges='false'>
     <pages>
         <page name='Frp'/>
         <page name='Validation'/>
+        <page name='Profunctor Optics'/>
+        <page name='Tuple'/>
     </pages>
 </playground>

--- a/Sources/Tuple/Tuple.swift
+++ b/Sources/Tuple/Tuple.swift
@@ -1,8 +1,8 @@
 import Prelude
 
 public struct Tuple<A, B> {
-  public let first: A
-  public let second: B
+  public var first: A
+  public var second: B
 }
 
 public typealias T2<A, Z> = Tuple<A, Z>


### PR DESCRIPTION
Was having problems using key paths on tuples and realized they aren't vars.