### PR TITLE
Add Tagged

### DIFF
--- a/Sources/Prelude/Tagged.swift
+++ b/Sources/Prelude/Tagged.swift
@@ -1,0 +1,28 @@
+public struct Tagged<Tag, A: Codable /* FIXME: conditional conformance */> {
+  public let unwrap: A
+
+  public init(unwrap: A) {
+    self.unwrap = unwrap
+  }
+}
+
+extension Tagged: Codable /* FIXME: where A: Codable */ {
+  public init(from decoder: Decoder) throws {
+    self.init(unwrap: try decoder.singleValueContainer().decode(A.self))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.unwrap)
+  }
+}
+
+extension Tagged: RawRepresentable {
+  public init?(rawValue: A) {
+    self.init(unwrap: rawValue)
+  }
+
+  public var rawValue: A {
+    return self.unwrap
+  }
+}


### PR DESCRIPTION
This adds a reusable, codable, phantomly `Tagged` type to Prelude. I started using it a bunch here: https://github.com/pointfreeco/pointfreeco/pull/52