### PR TITLE
Remove Tagged from Optics

### DIFF
--- a/Sources/Optics/Review.swift
+++ b/Sources/Optics/Review.swift
@@ -1,7 +1,3 @@
 import Prelude
 
-public struct Tagged<A, B> {
-  public let value: B
-}
-
-public typealias Review<S, T, A, B> = (Tagged<A, B>) -> Tagged<S, T>
+//public typealias Review<S, T, A, B> = (Tagged<A, B>) -> Tagged<S, T>


### PR DESCRIPTION
Missed this earlier! Didn't see the ambiguity till I started bumping deps down the chain.