### PR TITLE
Make tuple operator work on `T` values instead of `Tuple`

### DIFF
--- a/Sources/Tuple/Tuple.swift
+++ b/Sources/Tuple/Tuple.swift
@@ -3,6 +3,11 @@ import Prelude
 public struct Tuple<A, B> {
   public var first: A
   public var second: B
+
+  public init(_ first: A, _ second: B) {
+    self.first = first
+    self.second = second
+  }
 }
 
 public typealias T2<A, Z> = Tuple<A, Z>
@@ -22,22 +27,22 @@ public typealias Tuple6<A, B, C, D, E, F> = T7<A, B, C, D, E, F, Unit>
 infix operator .*.: infixr6
 
 public func .*. <A, B> (lhs: A, rhs: B) -> Tuple2<A, B> {
-  return .init(first: lhs, second: Tuple1(first: rhs, second: unit))
+  return .init(lhs, Tuple1(rhs, unit))
 }
 public func .*. <A, B> (lhs: A, rhs: Tuple1<B>) -> Tuple2<A, B> {
-  return .init(first: lhs, second: rhs)
+  return .init(lhs, rhs)
 }
 public func .*. <A, B, C> (lhs: A, rhs: Tuple2<B, C>) -> Tuple3<A, B, C> {
-  return .init(first: lhs, second: rhs)
+  return .init(lhs, rhs)
 }
 public func .*. <A, B, C, D> (lhs: A, rhs: Tuple3<B, C, D>) -> Tuple4<A, B, C, D> {
-  return .init(first: lhs, second: rhs)
+  return .init(lhs, rhs)
 }
 public func .*. <A, B, C, D, E> (lhs: A, rhs: Tuple4<B, C, D, E>) -> Tuple5<A, B, C, D, E> {
-  return .init(first: lhs, second: rhs)
+  return .init(lhs, rhs)
 }
 public func .*. <A, B, C, D, E, F> (lhs: A, rhs: Tuple5<B, C, D, E, F>) -> Tuple6<A, B, C, D, E, F> {
-  return .init(first: lhs, second: rhs)
+  return .init(lhs, rhs)
 }
 
 public func get1<A, Z>(_ t: T2<A, Z>) -> A {
@@ -60,20 +65,20 @@ public func get6<A, B, C, D, E, F, Z>(_ t: T7<A, B, C, D, E, F, Z>) -> F {
 }
 
 public func over1<A, R, Z>(_ o: @escaping (A) -> R) -> (T2<A, Z>) -> T2<R, Z> {
-  return { t in T2(first: o(t.first), second: t.second) }
+  return { t in T2(o(t.first), t.second) }
 }
 public func over2<A, B, R, Z>(_ o: @escaping (B) -> R) -> (T3<A, B, Z>) -> T3<A, R, Z> {
-  return { t in T3(first: t.first, second: T2(first: o(t.second.first), second: t.second.second)) }
+  return { t in T3(t.first, T2(o(t.second.first), t.second.second)) }
 }
 public func over3<A, B, C, R, Z>(_ o: @escaping (C) -> R) -> (T4<A, B, C, Z>) -> T4<A, B, R, Z> {
   return { t in
     T4(
-      first: t.first,
-      second: T3(
-        first: t.second.first,
-        second: T2(
-          first: o(t.second.second.first),
-          second: t.second.second.second
+      t.first,
+      T3(
+        t.second.first,
+        T2(
+          o(t.second.second.first),
+          t.second.second.second
         )
       )
     )
@@ -82,14 +87,14 @@ public func over3<A, B, C, R, Z>(_ o: @escaping (C) -> R) -> (T4<A, B, C, Z>) ->
 public func over4<A, B, C, D, R, Z>(_ o: @escaping (D) -> R) -> (T5<A, B, C, D, Z>) -> T5<A, B, C, R, Z> {
   return { t in
     T5(
-      first: t.first,
-      second: T4(
-        first: t.second.first,
-        second: T3(
-          first: t.second.second.first,
-          second: T2(
-            first: o(t.second.second.second.first),
-            second: t.second.second.second.second
+      t.first,
+      T4(
+        t.second.first,
+        T3(
+          t.second.second.first,
+          T2(
+            o(t.second.second.second.first),
+            t.second.second.second.second
           )
         )
       )
@@ -100,16 +105,16 @@ public func over5<A, B, C, D, E, R, Z>(_ o: @escaping (E) -> R) -> (T6<A, B, C, 
   -> T6<A, B, C, D, R, Z> {
     return { t in
       T6(
-        first: t.first,
-        second: T5(
-          first: t.second.first,
-          second: T4(
-            first: t.second.second.first,
-            second: T3(
-              first: t.second.second.second.first,
-              second: T2(
-                first: o(t.second.second.second.second.first),
-                second: t.second.second.second.second.second
+        t.first,
+        T5(
+          t.second.first,
+          T4(
+            t.second.second.first,
+            T3(
+              t.second.second.second.first,
+              T2(
+                o(t.second.second.second.second.first),
+                t.second.second.second.second.second
               )
             )
           )
@@ -121,18 +126,18 @@ public func over6<A, B, C, D, E, F, R, Z>(_ o: @escaping (F) -> R) -> (T7<A, B, 
   -> T7<A, B, C, D, E, R, Z> {
     return { t in
       T7(
-        first: t.first,
-        second: T6(
-          first: t.second.first,
-          second: T5(
-            first: t.second.second.first,
-            second: T4(
-              first: t.second.second.second.first,
-              second: T3(
-                first: t.second.second.second.second.first,
-                second: T2(
-                  first: o(t.second.second.second.second.second.first),
-                  second: t.second.second.second.second.second.second
+        t.first,
+        T6(
+          t.second.first,
+          T5(
+            t.second.second.first,
+            T4(
+              t.second.second.second.first,
+              T3(
+                t.second.second.second.second.first,
+                T2(
+                  o(t.second.second.second.second.second.first),
+                  t.second.second.second.second.second.second
                 )
               )
             )

--- a/Sources/Tuple/Tuple.swift
+++ b/Sources/Tuple/Tuple.swift
@@ -3,11 +3,6 @@ import Prelude
 public struct Tuple<A, B> {
   public var first: A
   public var second: B
-
-  public init(_ first: A, _ second: B) {
-    self.first = first
-    self.second = second
-  }
 }
 
 public typealias T2<A, Z> = Tuple<A, Z>
@@ -27,22 +22,22 @@ public typealias Tuple6<A, B, C, D, E, F> = T7<A, B, C, D, E, F, Unit>
 infix operator .*.: infixr6
 
 public func .*. <A, B> (lhs: A, rhs: B) -> Tuple2<A, B> {
-  return .init(lhs, Tuple1(rhs, unit))
+  return .init(first: lhs, second: Tuple1(first: rhs, second: unit))
 }
 public func .*. <A, B> (lhs: A, rhs: Tuple1<B>) -> Tuple2<A, B> {
-  return .init(lhs, rhs)
+  return .init(first: lhs, second: rhs)
 }
 public func .*. <A, B, C> (lhs: A, rhs: Tuple2<B, C>) -> Tuple3<A, B, C> {
-  return .init(lhs, rhs)
+  return .init(first: lhs, second: rhs)
 }
 public func .*. <A, B, C, D> (lhs: A, rhs: Tuple3<B, C, D>) -> Tuple4<A, B, C, D> {
-  return .init(lhs, rhs)
+  return .init(first: lhs, second: rhs)
 }
 public func .*. <A, B, C, D, E> (lhs: A, rhs: Tuple4<B, C, D, E>) -> Tuple5<A, B, C, D, E> {
-  return .init(lhs, rhs)
+  return .init(first: lhs, second: rhs)
 }
 public func .*. <A, B, C, D, E, F> (lhs: A, rhs: Tuple5<B, C, D, E, F>) -> Tuple6<A, B, C, D, E, F> {
-  return .init(lhs, rhs)
+  return .init(first: lhs, second: rhs)
 }
 
 public func get1<A, Z>(_ t: T2<A, Z>) -> A {
@@ -65,20 +60,20 @@ public func get6<A, B, C, D, E, F, Z>(_ t: T7<A, B, C, D, E, F, Z>) -> F {
 }
 
 public func over1<A, R, Z>(_ o: @escaping (A) -> R) -> (T2<A, Z>) -> T2<R, Z> {
-  return { t in T2(o(t.first), t.second) }
+  return { t in T2(first: o(t.first), second: t.second) }
 }
 public func over2<A, B, R, Z>(_ o: @escaping (B) -> R) -> (T3<A, B, Z>) -> T3<A, R, Z> {
-  return { t in T3(t.first, T2(o(t.second.first), t.second.second)) }
+  return { t in T3(first: t.first, second: T2(first: o(t.second.first), second: t.second.second)) }
 }
 public func over3<A, B, C, R, Z>(_ o: @escaping (C) -> R) -> (T4<A, B, C, Z>) -> T4<A, B, R, Z> {
   return { t in
     T4(
-      t.first,
-      T3(
-        t.second.first,
-        T2(
-          o(t.second.second.first),
-          t.second.second.second
+      first: t.first,
+      second: T3(
+        first: t.second.first,
+        second: T2(
+          first: o(t.second.second.first),
+          second: t.second.second.second
         )
       )
     )
@@ -87,14 +82,14 @@ public func over3<A, B, C, R, Z>(_ o: @escaping (C) -> R) -> (T4<A, B, C, Z>) ->
 public func over4<A, B, C, D, R, Z>(_ o: @escaping (D) -> R) -> (T5<A, B, C, D, Z>) -> T5<A, B, C, R, Z> {
   return { t in
     T5(
-      t.first,
-      T4(
-        t.second.first,
-        T3(
-          t.second.second.first,
-          T2(
-            o(t.second.second.second.first),
-            t.second.second.second.second
+      first: t.first,
+      second: T4(
+        first: t.second.first,
+        second: T3(
+          first: t.second.second.first,
+          second: T2(
+            first: o(t.second.second.second.first),
+            second: t.second.second.second.second
           )
         )
       )
@@ -105,16 +100,16 @@ public func over5<A, B, C, D, E, R, Z>(_ o: @escaping (E) -> R) -> (T6<A, B, C, 
   -> T6<A, B, C, D, R, Z> {
     return { t in
       T6(
-        t.first,
-        T5(
-          t.second.first,
-          T4(
-            t.second.second.first,
-            T3(
-              t.second.second.second.first,
-              T2(
-                o(t.second.second.second.second.first),
-                t.second.second.second.second.second
+        first: t.first,
+        second: T5(
+          first: t.second.first,
+          second: T4(
+            first: t.second.second.first,
+            second: T3(
+              first: t.second.second.second.first,
+              second: T2(
+                first: o(t.second.second.second.second.first),
+                second: t.second.second.second.second.second
               )
             )
           )
@@ -126,18 +121,18 @@ public func over6<A, B, C, D, E, F, R, Z>(_ o: @escaping (F) -> R) -> (T7<A, B, 
   -> T7<A, B, C, D, E, R, Z> {
     return { t in
       T7(
-        t.first,
-        T6(
-          t.second.first,
-          T5(
-            t.second.second.first,
-            T4(
-              t.second.second.second.first,
-              T3(
-                t.second.second.second.second.first,
-                T2(
-                  o(t.second.second.second.second.second.first),
-                  t.second.second.second.second.second.second
+        first: t.first,
+        second: T6(
+          first: t.second.first,
+          second: T5(
+            first: t.second.second.first,
+            second: T4(
+              first: t.second.second.second.first,
+              second: T3(
+                first: t.second.second.second.second.first,
+                second: T2(
+                  first: o(t.second.second.second.second.second.first),
+                  second: t.second.second.second.second.second.second
                 )
               )
             )

--- a/Sources/Tuple/Tuple.swift
+++ b/Sources/Tuple/Tuple.swift
@@ -21,22 +21,22 @@ public typealias Tuple6<A, B, C, D, E, F> = T7<A, B, C, D, E, F, Unit>
 
 infix operator .*.: infixr6
 
-public func .*. <A, B> (lhs: A, rhs: B) -> Tuple2<A, B> {
-  return .init(first: lhs, second: Tuple1(first: rhs, second: unit))
-}
-public func .*. <A, B> (lhs: A, rhs: Tuple1<B>) -> Tuple2<A, B> {
+public func .*. <A, B> (lhs: A, rhs: B) -> T2<A, B> {
   return .init(first: lhs, second: rhs)
 }
-public func .*. <A, B, C> (lhs: A, rhs: Tuple2<B, C>) -> Tuple3<A, B, C> {
+public func .*. <A, B, C> (lhs: A, rhs: T2<B, C>) -> T3<A, B, C> {
   return .init(first: lhs, second: rhs)
 }
-public func .*. <A, B, C, D> (lhs: A, rhs: Tuple3<B, C, D>) -> Tuple4<A, B, C, D> {
+public func .*. <A, B, C, D> (lhs: A, rhs: T3<B, C, D>) -> T4<A, B, C, D> {
   return .init(first: lhs, second: rhs)
 }
-public func .*. <A, B, C, D, E> (lhs: A, rhs: Tuple4<B, C, D, E>) -> Tuple5<A, B, C, D, E> {
+public func .*. <A, B, C, D, E> (lhs: A, rhs: T4<B, C, D, E>) -> T5<A, B, C, D, E> {
   return .init(first: lhs, second: rhs)
 }
-public func .*. <A, B, C, D, E, F> (lhs: A, rhs: Tuple5<B, C, D, E, F>) -> Tuple6<A, B, C, D, E, F> {
+public func .*. <A, B, C, D, E, F> (lhs: A, rhs: T5<B, C, D, E, F>) -> T6<A, B, C, D, E, F> {
+  return .init(first: lhs, second: rhs)
+}
+public func .*. <A, B, C, D, E, F, G> (lhs: A, rhs: T6<B, C, D, E, F, G>) -> T7<A, B, C, D, E, F, G> {
   return .init(first: lhs, second: rhs)
 }
 
@@ -174,19 +174,19 @@ public func == <A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equat
 }
 
 public func lift<A, B>(_ tuple: (A, B)) -> Tuple2<A, B> {
-  return tuple.0 .*. tuple.1
+  return tuple.0 .*. tuple.1 .*. unit
 }
 public func lift<A, B, C>(_ tuple: (A, B, C)) -> Tuple3<A, B, C> {
-  return tuple.0 .*. tuple.1 .*. tuple.2
+  return tuple.0 .*. tuple.1 .*. tuple.2 .*. unit
 }
 public func lift<A, B, C, D>(_ tuple: (A, B, C, D)) -> Tuple4<A, B, C, D> {
-  return tuple.0 .*. tuple.1 .*. tuple.2 .*. tuple.3
+  return tuple.0 .*. tuple.1 .*. tuple.2 .*. tuple.3 .*. unit
 }
 public func lift<A, B, C, D, E>(_ tuple: (A, B, C, D, E)) -> Tuple5<A, B, C, D, E> {
-  return tuple.0 .*. tuple.1 .*. tuple.2 .*. tuple.3 .*. tuple.4
+  return tuple.0 .*. tuple.1 .*. tuple.2 .*. tuple.3 .*. tuple.4 .*. unit
 }
 public func lift<A, B, C, D, E, F>(_ tuple: (A, B, C, D, E, F)) -> Tuple6<A, B, C, D, E, F> {
-  return tuple.0 .*. tuple.1 .*. tuple.2 .*. tuple.3 .*. tuple.4 .*. tuple.5
+  return tuple.0 .*. tuple.1 .*. tuple.2 .*. tuple.3 .*. tuple.4 .*. tuple.5 .*. unit
 }
 
 public func lower<A, B>(_ tuple: Tuple2<A, B>) -> (A, B) {

--- a/Sources/Tuple/Tuple.swift
+++ b/Sources/Tuple/Tuple.swift
@@ -59,120 +59,94 @@ public func get6<A, B, C, D, E, F, Z>(_ t: T7<A, B, C, D, E, F, Z>) -> F {
   return t.second.second.second.second.second.first
 }
 
-public func over1<A, R, Z>(_ o: @escaping (A) -> R) -> (T2<A, Z>) -> T2<R, Z> {
-  return { t in T2(first: o(t.first), second: t.second) }
+public func rest<A, Z>(_ t: T2<A, Z>) -> Z {
+  return t.second
 }
-public func over2<A, B, R, Z>(_ o: @escaping (B) -> R) -> (T3<A, B, Z>) -> T3<A, R, Z> {
-  return { t in T3(first: t.first, second: T2(first: o(t.second.first), second: t.second.second)) }
+public func rest<A, B, Z>(_ t: T3<A, B, Z>) -> Z {
+  return t.second.second
 }
-public func over3<A, B, C, R, Z>(_ o: @escaping (C) -> R) -> (T4<A, B, C, Z>) -> T4<A, B, R, Z> {
-  return { t in
-    T4(
-      first: t.first,
-      second: T3(
-        first: t.second.first,
-        second: T2(
-          first: o(t.second.second.first),
-          second: t.second.second.second
-        )
-      )
-    )
-  }
+public func rest<A, B, C, Z>(_ t: T4<A, B, C, Z>) -> Z {
+  return t.second.second.second
 }
-public func over4<A, B, C, D, R, Z>(_ o: @escaping (D) -> R) -> (T5<A, B, C, D, Z>) -> T5<A, B, C, R, Z> {
-  return { t in
-    T5(
-      first: t.first,
-      second: T4(
-        first: t.second.first,
-        second: T3(
-          first: t.second.second.first,
-          second: T2(
-            first: o(t.second.second.second.first),
-            second: t.second.second.second.second
-          )
-        )
-      )
-    )
-  }
+public func rest<A, B, C, D, Z>(_ t: T5<A, B, C, D, Z>) -> Z {
+  return t.second.second.second.second
 }
-public func over5<A, B, C, D, E, R, Z>(_ o: @escaping (E) -> R) -> (T6<A, B, C, D, E, Z>)
-  -> T6<A, B, C, D, R, Z> {
-    return { t in
-      T6(
-        first: t.first,
-        second: T5(
-          first: t.second.first,
-          second: T4(
-            first: t.second.second.first,
-            second: T3(
-              first: t.second.second.second.first,
-              second: T2(
-                first: o(t.second.second.second.second.first),
-                second: t.second.second.second.second.second
-              )
-            )
-          )
-        )
-      )
-    }
+public func rest<A, B, C, D, E, Z>(_ t: T6<A, B, C, D, E, Z>) -> Z {
+  return t.second.second.second.second.second
 }
-public func over6<A, B, C, D, E, F, R, Z>(_ o: @escaping (F) -> R) -> (T7<A, B, C, D, E, F, Z>)
-  -> T7<A, B, C, D, E, R, Z> {
-    return { t in
-      T7(
-        first: t.first,
-        second: T6(
-          first: t.second.first,
-          second: T5(
-            first: t.second.second.first,
-            second: T4(
-              first: t.second.second.second.first,
-              second: T3(
-                first: t.second.second.second.second.first,
-                second: T2(
-                  first: o(t.second.second.second.second.second.first),
-                  second: t.second.second.second.second.second.second
-                )
-              )
-            )
-          )
-        )
-      )
-    }
+public func rest<A, B, C, D, E, F, Z>(_ t: T7<A, B, C, D, E, F, Z>) -> Z {
+  return t.second.second.second.second.second.second
 }
 
-public func == <A: Equatable, B: Equatable> (lhs: Tuple<A, B>, rhs: Tuple<A, B>) -> Bool {
-  return lhs.first == rhs.first && lhs.second == rhs.second
+public func over1<A, R, Z>(_ o: @escaping (A) -> R) -> (T2<A, Z>) -> T2<R, Z> {
+  return { t in o(t.first) .*. t.second }
+}
+public func over2<A, B, R, Z>(_ o: @escaping (B) -> R) -> (T3<A, B, Z>) -> T3<A, R, Z> {
+  return { t in get1(t) .*. o(get2(t)) .*. rest(t) }
+}
+public func over3<A, B, C, R, Z>(_ o: @escaping (C) -> R) -> (T4<A, B, C, Z>) -> T4<A, B, R, Z> {
+  return { t in get1(t) .*. get2(t) .*. o(get3(t)) .*. rest(t) }
+}
+public func over4<A, B, C, D, R, Z>(_ o: @escaping (D) -> R) -> (T5<A, B, C, D, Z>) -> T5<A, B, C, R, Z> {
+  return { t in get1(t) .*. get2(t) .*. get3(t) .*. o(get4(t)) .*. rest(t) }
+}
+public func over5<A, B, C, D, E, R, Z>(
+  _ o: @escaping (E) -> R
+  )
+  -> (T6<A, B, C, D, E, Z>)
+  -> T6<A, B, C, D, R, Z> {
+
+    return { t in get1(t) .*. get2(t) .*. get3(t) .*. get4(t) .*. o(get5(t)) .*. rest(t) }
+}
+public func over6<A, B, C, D, E, F, R, Z>(
+  _ o: @escaping (F) -> R
+  )
+  -> (T7<A, B, C, D, E, F, Z>)
+  -> T7<A, B, C, D, E, R, Z> {
+
+    return { t in get1(t) .*. get2(t) .*. get3(t) .*. get4(t) .*. get5(t) .*. o(get6(t)) .*. rest(t) }
+}
+
+public func == <A: Equatable, Z: Equatable> (lhs: T2<A, Z>, rhs: T2<A, Z>) -> Bool {
+  return get1(lhs) == get1(rhs) && rest(lhs) == rest(rhs)
 }
 public func == <A: Equatable, B: Equatable> (lhs: Tuple2<A, B>, rhs: Tuple2<A, B>) -> Bool {
   return lhs.first == rhs.first && lhs.second == rhs.second
 }
-public func == <A: Equatable, B: Equatable, C: Equatable> (
-  lhs: Tuple3<A, B, C>,
-  rhs: Tuple3<A, B, C>
+public func == <A: Equatable, B: Equatable, Z: Equatable> (
+  lhs: T3<A, B, Z>,
+  rhs: T3<A, B, Z>
   ) -> Bool {
   return lhs.first == rhs.first && lhs.second == rhs.second
 }
 public func == <A: Equatable, B: Equatable, C: Equatable, D: Equatable> (
-  lhs: Tuple4<A, B, C, D>,
-  rhs: Tuple4<A, B, C, D>
+  lhs: T4<A, B, C, D>,
+  rhs: T4<A, B, C, D>
   ) -> Bool {
   return lhs.first == rhs.first && lhs.second == rhs.second
 }
 public func == <A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable> (
-  lhs: Tuple5<A, B, C, D, E>,
-  rhs: Tuple5<A, B, C, D, E>
+  lhs: T5<A, B, C, D, E>,
+  rhs: T5<A, B, C, D, E>
   ) -> Bool {
   return lhs.first == rhs.first && lhs.second == rhs.second
 }
 public func == <A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable> (
-  lhs: Tuple6<A, B, C, D, E, F>,
-  rhs: Tuple6<A, B, C, D, E, F>
+  lhs: T6<A, B, C, D, E, F>,
+  rhs: T6<A, B, C, D, E, F>
+  ) -> Bool {
+  return lhs.first == rhs.first && lhs.second == rhs.second
+}
+public func == <A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable> (
+  lhs: T7<A, B, C, D, E, F, G>,
+  rhs: T7<A, B, C, D, E, F, G>
   ) -> Bool {
   return lhs.first == rhs.first && lhs.second == rhs.second
 }
 
+public func lift<A>(_ a: A) -> Tuple1<A> {
+  return Tuple1(first: a, second: unit)
+}
 public func lift<A, B>(_ tuple: (A, B)) -> Tuple2<A, B> {
   return tuple.0 .*. tuple.1 .*. unit
 }

--- a/Tests/TupleTests/TupleTests.swift
+++ b/Tests/TupleTests/TupleTests.swift
@@ -14,5 +14,12 @@ final class TupleTests: XCTestCase {
     XCTAssertTrue(
       2 .*. "hello" .*. true .*. 2.0 .*. unit == (tuple |> over1({ $0 + 1 }))
     )
+
+    let loweredTuple = lower(tuple)
+
+    XCTAssertEqual(1, loweredTuple.0)
+    XCTAssertEqual("hello", loweredTuple.1)
+    XCTAssertEqual(true, loweredTuple.2)
+    XCTAssertEqual(2.0, loweredTuple.3)
   }
 }

--- a/Tests/TupleTests/TupleTests.swift
+++ b/Tests/TupleTests/TupleTests.swift
@@ -5,14 +5,14 @@ import XCTest
 final class TupleTests: XCTestCase {
 
   func testTuples() {
-    let tuple = 1 .*. "hello" .*. true .*. 2.0
+    let tuple = 1 .*. "hello" .*. true .*. 2.0 .*. unit
 
     XCTAssertEqual(1, tuple |> get1)
     XCTAssertEqual("hello", tuple |> get2)
     XCTAssertEqual(true, tuple |> get3)
     XCTAssertEqual(2.0, tuple |> get4)
     XCTAssertTrue(
-      2 .*. "hello" .*. true .*. 2.0 == (tuple |> over1({ $0 + 1 }))
+      2 .*. "hello" .*. true .*. 2.0 .*. unit == (tuple |> over1({ $0 + 1 }))
     )
   }
 }


### PR DESCRIPTION
I've been having problems constructing `T2` values in `pointfreeco`, and realized that `.*.` should be operating on `T` not `Tuple`.

I think now it's much clearer how the `T` values capture a subset of a tuple that carries something like a continuation with it. For example, doing this does not give you a `Tuple3`

```swift
let value = 1 .*. "hello" .*. true
```

cause you have not terminated the continuation by doing `.*. unit`. Once you do this:

```swift
let value = 1 .*. "hello" .*. true .*. unit
```

you'll have a proper `Tuple3<Int, String, Bool>`!