### PR TITLE
Add support for CocoaPods

### DIFF
--- a/Swift-Prelude.podspec
+++ b/Swift-Prelude.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name        = "Swift-Prelude"
+  s.version     = "0.1.2"
+  s.summary     = "🎶 A collection of types and functions that enhance the Swift language."
+  s.homepage    = "https://github.com/pointfreeco/swift-prelude"
+  s.license     = { :type => "MIT" }
+  s.authors     = { "mbrandonw" => "brandon@pointfree.co", "stephencelis" => "stephen@pointfree.co" }
+
+  s.requires_arc = true
+  s.swift_version = "4.1.1"
+  s.osx.deployment_target = "10.9"
+  s.ios.deployment_target = "8.0"
+  s.watchos.deployment_target = "3.0"
+  s.tvos.deployment_target = "9.0"
+  s.source   = { :git => "https://github.com/pointfreeco/swift-prelude.git", :tag => s.version }
+  s.source_files = "Sources/*/*.swift"
+end

--- a/Swift-Prelude.podspec
+++ b/Swift-Prelude.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.source   = { :git => "https://github.com/pointfreeco/swift-prelude.git", :tag => s.version }
   s.source_files = "Sources/*/*.swift"
+  s.module_name = "Prelude"
 end

--- a/Swift-Prelude.podspec
+++ b/Swift-Prelude.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary     = "🎶 A collection of types and functions that enhance the Swift language."
   s.homepage    = "https://github.com/pointfreeco/swift-prelude"
   s.license     = { :type => "MIT" }
-  s.authors     = { "mbrandonw" => "brandon@pointfree.co", "stephencelis" => "stephen@pointfree.co" }
+  s.authors     = { "Brandon Williams" => "brandon@pointfree.co", "Stephen Celis" => "stephen@pointfree.co" }
 
   s.requires_arc = true
   s.swift_version = "4.1.1"


### PR DESCRIPTION
I think there are a few things that need to be done before this is ready to go:

- [ ] Add a new 0.1.3 (or whatever) release
- [ ] Update `.podspec` to point to that release
- [ ] Verify that emails are correct in the `.podspec` (I guessed)
- [ ] Verify that deployment targets are correct
- [ ] Run `pod spec lint` to make sure it can be built with the latest code
- [ ] Upload spec to trunk (here is a [helpful guide](https://guides.cocoapods.org/making/getting-setup-with-trunk.html))