### PR TITLE
Update snapshot testing to 1.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "SnapshotTesting",
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {
-          "branch": "ca1a008",
-          "revision": "ca1a0080b99b7501ddad49d9e7aa6e5971716371",
-          "version": null
+          "branch": null,
+          "revision": "129e393c6d17f7f6490fa212f19ae0d558bbd5dc",
+          "version": "1.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .library(name: "Writer", targets: ["Writer"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .revision("ca1a008")),
+    .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-nonempty.git", from: "0.1.2"),
     .package(url: "https://github.com/pointfreeco/swift-tagged.git", from: "0.2.0"),
   ],


### PR DESCRIPTION
Wanted to use newest snapshot testing in pointfreeco but have a few of these to update.

honestly... I kinda think we could remove snapshot testing from this lib. it's not doing too much.

or maybe this lib re-exports it? can swift-web then further re-export it for use in pointfreeco?