### PR TITLE
Remove unused internal Tuple initializer

### DIFF
--- a/Sources/Tuple/Tuple.swift
+++ b/Sources/Tuple/Tuple.swift
@@ -25,13 +25,6 @@ public func .*. <A, B> (lhs: A, rhs: B) -> T2<A, B> {
   return .init(first: lhs, second: rhs)
 }
 
-extension Tuple {
-  init<B1, C>(a: A, b: B1, c: C) where Tuple == Tuple3<A, B1, C> {
-    self.first = a
-    self.second = b .*. c .*. unit
-  }
-}
-
 public func get1<A, Z>(_ t: T2<A, Z>) -> A {
   return t.first
 }


### PR DESCRIPTION
Thanks for so quickly answering my question in #133, might as well help out again. :)

The internal initializer of `Tuple` being removed produces a warning when building in Xcode 10.2.1. Removing it removes the warning and causes no further issues as it's unused internally.