### PR TITLE
Adds more keyboard agnostic operator <^> definition for map.

### DIFF
--- a/Sources/Either/Either.swift
+++ b/Sources/Either/Either.swift
@@ -107,6 +107,10 @@ extension Either {
   public static func <¢> <A>(r2a: (R) -> A, lr: Either) -> Either<L, A> {
     return lr.map(r2a)
   }
+
+  public static func <^> <A>(r2a: (R) -> A, lr: Either) -> Either<L, A> {
+      return lr.map(r2a)
+  }
 }
 
 public func map<A, B, C>(_ b2c: @escaping (B) -> C) -> (Either<A, B>) -> Either<A, C> {

--- a/Sources/Either/EitherIO.swift
+++ b/Sources/Either/EitherIO.swift
@@ -99,6 +99,10 @@ extension EitherIO {
   public static func <¢> <B>(f: @escaping (A) -> B, x: EitherIO) -> EitherIO<E, B> {
     return x.map(f)
   }
+
+  public static func <^> <B>(f: @escaping (A) -> B, x: EitherIO) -> EitherIO<E, B> {
+      return x.map(f)
+  }
 }
 
 public func map<E, A, B>(_ f: @escaping (A) -> B) -> (EitherIO<E, A>) -> EitherIO<E, B> {

--- a/Sources/Frp/Event.swift
+++ b/Sources/Frp/Event.swift
@@ -144,12 +144,24 @@ extension Event {
     return a.map(a2b)
   }
 
+  public static func <^> <B>(a2b: @escaping (A) -> B, a: Event<A>) -> Event<B> {
+      return a.map(a2b)
+  }
+
   public static func <¢ <B>(a: A, p: Event<B>) -> Event {
     return const(a) <¢> p
   }
 
+  public static func <^ <B>(a: A, p: Event<B>) -> Event {
+      return const(a) <¢> p
+  }
+
   public static func ¢> <B>(p: Event<B>, a: A) -> Event {
     return const(a) <¢> p
+  }
+
+  public static func ^> <B>(p: Event<B>, a: A) -> Event {
+      return const(a) <¢> p
   }
 }
 

--- a/Sources/Prelude/Func.swift
+++ b/Sources/Prelude/Func.swift
@@ -25,6 +25,10 @@ extension Func /* : Functor */ {
   public static func <¢> <C>(f: @escaping (B) -> C, g: Func) -> Func<A, C> {
     return g.map(f)
   }
+
+  public static func <^> <C>(f: @escaping (B) -> C, g: Func) -> Func<A, C> {
+      return g.map(f)
+  }
 }
 
 public func map<A, B, C>(_ f: @escaping (B) -> C) -> (Func<A, B>) -> Func<A, C> {

--- a/Sources/Prelude/IO.swift
+++ b/Sources/Prelude/IO.swift
@@ -84,6 +84,10 @@ extension IO {
   public static func <¢> <B>(f: @escaping (A) -> B, x: IO<A>) -> IO<B> {
     return x.map(f)
   }
+
+  public static func <^> <B>(f: @escaping (A) -> B, x: IO<A>) -> IO<B> {
+      return x.map(f)
+  }
 }
 
 public func map<A, B>(_ f: @escaping (A) -> B) -> (IO<A>) -> IO<B> {

--- a/Sources/Prelude/Operators.swift
+++ b/Sources/Prelude/Operators.swift
@@ -11,6 +11,10 @@ infix operator ¢>: infixl4
 infix operator <¢: infixl4
 infix operator <£>: infixl1
 
+infix operator <^>: infixl4
+infix operator ^>: infixl4
+infix operator <^: infixl4
+
 // Contravariant
 infix operator >¢<: infixl4
 infix operator >£<: infixl4

--- a/Sources/Prelude/Optional.swift
+++ b/Sources/Prelude/Optional.swift
@@ -23,6 +23,10 @@ extension Optional {
   public static func <¢> <A>(f: (Wrapped) -> A, x: Optional) -> A? {
     return x.map(f)
   }
+
+  public static func <^> <A>(f: (Wrapped) -> A, x: Optional) -> A? {
+      return x.map(f)
+  }
 }
 
 public func map<A, B>(_ a2b: @escaping (A) -> B) -> (A?) -> B? {

--- a/Sources/Prelude/Parallel.swift
+++ b/Sources/Prelude/Parallel.swift
@@ -52,6 +52,10 @@ extension Parallel {
   public static func <¢> <B>(f: @escaping (A) -> B, x: Parallel<A>) -> Parallel<B> {
     return x.map(f)
   }
+
+  public static func <^> <B>(f: @escaping (A) -> B, x: Parallel<A>) -> Parallel<B> {
+      return x.map(f)
+  }
 }
 
 public func map<A, B>(_ f: @escaping (A) -> B) -> (Parallel<A>) -> Parallel<B> {

--- a/Sources/Prelude/Sequence.swift
+++ b/Sources/Prelude/Sequence.swift
@@ -14,6 +14,10 @@ extension Sequence {
   public static func <¢> <A>(f: (Element) -> A, xs: Self) -> [A] {
     return xs.map(f)
   }
+
+  public static func <^> <A>(f: (Element) -> A, xs: Self) -> [A] {
+      return xs.map(f)
+  }
 }
 
 public func map<S: Sequence, A>(_ f: @escaping (S.Element) -> A) -> (S) -> [A] {

--- a/Sources/Reader/Reader.swift
+++ b/Sources/Reader/Reader.swift
@@ -18,6 +18,10 @@ extension Reader {
   public static func <¢> <R, A, B> (f: @escaping (A) -> B, reader: Reader<R, A>) -> Reader<R, B> {
     return reader.map(f)
   }
+
+  public static func <^> <R, A, B> (f: @escaping (A) -> B, reader: Reader<R, A>) -> Reader<R, B> {
+      return reader.map(f)
+  }
 }
 
 // MARK: - Apply

--- a/Sources/State/State.swift
+++ b/Sources/State/State.swift
@@ -51,6 +51,10 @@ extension State {
   public static func <¢> <B>(a2b: @escaping (A) -> B, sa: State<S, A>) -> State<S, B> {
     return sa.map(a2b)
   }
+
+  public static func <^> <B>(a2b: @escaping (A) -> B, sa: State<S, A>) -> State<S, B> {
+      return sa.map(a2b)
+  }
 }
 
 // MARK: - Apply

--- a/Sources/ValidationNearSemiring/ValidationNearSemiring.swift
+++ b/Sources/ValidationNearSemiring/ValidationNearSemiring.swift
@@ -43,6 +43,10 @@ extension Validation {
   public static func <¢> <B>(a2b: (A) -> B, a: Validation) -> Validation<E, B> {
     return a.map(a2b)
   }
+
+  public static func <^> <B>(a2b: (A) -> B, a: Validation) -> Validation<E, B> {
+      return a.map(a2b)
+  }
 }
 
 public func map<A, B, C>(_ b2c: @escaping (B) -> C)

--- a/Sources/ValidationSemigroup/ValidationSemigroup.swift
+++ b/Sources/ValidationSemigroup/ValidationSemigroup.swift
@@ -43,6 +43,10 @@ extension Validation {
   public static func <¢> <B>(a2b: (A) -> B, a: Validation) -> Validation<E, B> {
     return a.map(a2b)
   }
+
+  public static func <^> <B>(a2b: (A) -> B, a: Validation) -> Validation<E, B> {
+      return a.map(a2b)
+  }
 }
 
 public func map<A, B, C>(_ b2c: @escaping (B) -> C)

--- a/Sources/Writer/Writer.swift
+++ b/Sources/Writer/Writer.swift
@@ -24,6 +24,10 @@ extension Writer {
   public static func <¢> <W, A, B> (f: @escaping (A) -> B, writer: Writer<W, A>) -> Writer<W, B> {
     return writer.map(f)
   }
+
+  public static func <^> <W, A, B> (f: @escaping (A) -> B, writer: Writer<W, A>) -> Writer<W, B> {
+      return writer.map(f)
+  }
 }
 
 // MARK: - Apply


### PR DESCRIPTION
Unfortunately `¢` and `£` are no so accessible if you are not on an EN keyboard layout (eg. € <- Option 3; ß <- Option 4).  Also, this `<^>` operator is more common "in the wild" (eg. https://youtu.be/ICnZq3MfrMA?t=1512 25:12) and it "plays along" with the operator for lifting key paths`^`.