### PR TITLE
feat(Func): Add callAsFunction method

### DIFF
--- a/Sources/Prelude/Func.swift
+++ b/Sources/Prelude/Func.swift
@@ -1,5 +1,24 @@
+public protocol FuncProtocol {
+  associatedtype A
+  associatedtype B
+  typealias Signature = (A) -> B
+  var call: Signature { get }
+  init(_ call: @escaping Signature)
+}
 
-public struct Func<A, B> {
+extension FuncProtocol {
+  public func callAsFunction(_ input: A) -> B {
+    return call(input)
+  }
+}
+
+extension FuncProtocol where A == Void {
+  public func callAsFunction() -> B {
+    return call(())
+  }
+}
+
+public struct Func<A, B>: FuncProtocol {
   public let call: (A) -> B
 
   public init(_ call: @escaping (A) -> B) {

--- a/Sources/Prelude/Func.swift
+++ b/Sources/Prelude/Func.swift
@@ -1,24 +1,4 @@
-public protocol FuncProtocol {
-  associatedtype A
-  associatedtype B
-  typealias Signature = (A) -> B
-  var call: Signature { get }
-  init(_ call: @escaping Signature)
-}
-
-extension FuncProtocol {
-  public func callAsFunction(_ input: A) -> B {
-    return call(input)
-  }
-}
-
-extension FuncProtocol where A == Void {
-  public func callAsFunction() -> B {
-    return call(())
-  }
-}
-
-public struct Func<A, B>: FuncProtocol {
+public struct Func<A, B>: Function {
   public let call: (A) -> B
 
   public init(_ call: @escaping (A) -> B) {
@@ -26,45 +6,77 @@ public struct Func<A, B>: FuncProtocol {
   }
 }
 
-extension Func /* : Semigroupoid */ {
-  public static func >>> <C>(f: Func, g: Func<B, C>) -> Func<A, C> {
+public protocol Function {
+  associatedtype A
+  associatedtype B
+  typealias Signature = (A) -> B
+  var call: Signature { get }
+  init(_ call: @escaping Signature)
+}
+
+extension Function {
+  public func eraseToFunc() -> Func<A, B> {
+    return Func(call)
+  }
+}
+
+extension Function {
+  public func callAsFunction(_ input: A) -> B {
+    return call(input)
+  }
+}
+
+extension Function where A == Void {
+  public func callAsFunction() -> B {
+    return call(())
+  }
+}
+
+extension Function /* : Semigroupoid */ {
+  public static func >>> <G: Function>(f: Self, g: G) -> Func<A, G.B> where G.A == B {
     return .init(f.call >>> g.call)
   }
 
-  public static func <<< <C>(f: Func<B, C>, g: Func) -> Func<A, C> {
+  public static func <<< <F: Function>(f: F, g: Self) -> Func<A, F.B> where F.A == B {
     return .init(f.call <<< g.call)
   }
 }
 
-extension Func /* : Functor */ {
+extension Function /* : Functor */ {
   public func map<C>(_ f: @escaping (B) -> C) -> Func<A, C> {
     return .init(self.call >>> f)
   }
 
-  public static func <¢> <C>(f: @escaping (B) -> C, g: Func) -> Func<A, C> {
+  public static func <¢> <C>(f: @escaping (B) -> C, g: Self) -> Func<A, C> {
     return g.map(f)
   }
 }
 
-public func map<A, B, C>(_ f: @escaping (B) -> C) -> (Func<A, B>) -> Func<A, C> {
+public func map<A, B, C, F: Function>(_ f: @escaping (B) -> C) -> (F) -> Func<A, C>
+where F.A == A, F.B == B {
   return { $0.map(f) }
 }
 
-extension Func /* : Contravariant */ {
+extension Function {
   public func contramap<Z>(_ f: @escaping (Z) -> A) -> Func<Z, B> {
     return .init(f >>> self.call)
   }
+}
 
+// Have to implement in on a Func type directly due to compilation error:
+// - Member operator '>¢<' of protocol 'Function' must have at least one argument of type 'Self'
+extension Func /* : Contravariant */ {
   public static func >¢< <A, B, C>(f: @escaping (B) -> A, g: Func<A, C>) -> Func<B, C> {
     return g.contramap(f)
   }
 }
 
-public func contramap<A, B, C>(_ f: @escaping (B) -> A) -> (Func<A, C>) -> Func<B, C> {
+public func contramap<A, B, C, G: Function>(_ f: @escaping (B) -> A) -> (G) -> Func<B, C>
+where G.A == A, G.B == C {
   return { $0.contramap(f) }
 }
 
-extension Func /* : Profunctor */ {
+extension Function /* : Profunctor */ {
   public func dimap<Z, C>(_ f: @escaping (Z) -> A, _ g: @escaping (B) -> C) -> Func<Z, C> {
     return .init(f >>> self.call >>> g)
   }
@@ -76,67 +88,84 @@ public func dimap<A, B, C, D>(
   )
   -> (Func<B, C>)
   -> Func<A, D> {
-
     return { $0.dimap(f, g) }
 }
 
-extension Func /* : Apply */ {
-  public func apply<C>(_ f: Func<A, Func<B, C>>) -> Func<A, C> {
+extension Function /* : Apply */ {
+  public func apply<F: Function, G: Function, C>(_ f: F) -> Func<A, C>
+  where F.A == A, F.B == G, G.A == B, G.B == C {
     return .init { a in f.call(a).call(self.call(a)) }
   }
 
-  public static func <*> <C>(f: Func<A, Func<B, C>>, x: Func) -> Func<A, C> {
+  public static func <*> <F: Function, G: Function, C>(f: F, x: Self) -> Func<A, C>
+  where F.A == A, F.B == G, G.A == B, G.B == C {
     return x.apply(f)
   }
 }
 
-public func apply<A, B, C>(_ f: Func<A, Func<B, C>>) -> (Func<A, B>) -> Func<A, C> {
+public func apply<F: Function, G: Function, B, C>(_ f: F) -> (Func<F.A, B>) -> Func<F.A, C>
+where F.B == G, G.A == B, G.B == C {
   return { $0.apply(f) }
 }
 
 // MARK: Applicative
+extension Function {
+  public static func pure(_ b: B) -> Self {
+    .init(const(b))
+  }
+}
+
 public func pure<A, B>(_ b: B) -> Func<A, B> {
   return .init(const(b))
 }
 
-extension Func /* : Monad */ {
-  public func flatMap<C>(_ f: @escaping (B) -> Func<A, C>) -> Func<A, C> {
+extension Function /* : Monad */ {
+  public func flatMap<F: Function>(_ f: @escaping (B) -> F) -> Func<A, F.B>
+  where F.A == A {
     return .init { f(self.call($0)).call($0) }
   }
 }
 
-public func flatMap<A, B, C>(_ f: @escaping (B) -> Func<A, C>) -> (Func<A, B>) -> Func<A, C> {
+public func flatMap<F: Function, C>(_ f: @escaping (C) -> F) -> (Func<F.A, C>) -> Func<F.A, F.B> {
   return { $0.flatMap(f) }
 }
 
-extension Func: Semigroup where B: Semigroup {
-  public static func <> (f: Func, g: Func) -> Func {
+extension Function where B: Semigroup {
+  public static func <> (f: Self, g: Self) -> Self {
     return .init { f.call($0) <> g.call($0) }
   }
 }
 
-extension Func: Monoid where B: Monoid {
-  public static var empty: Func {
+extension Func: Semigroup where B: Semigroup {}
+
+extension Function where B: Monoid {
+  public static var empty: Self {
     return .init(const(B.empty))
   }
 }
+  
+extension Func: Monoid where B: Monoid {}
 
-extension Func: NearSemiring where B: NearSemiring {
-  public static func + (f: Func, g: Func) -> Func {
+extension Function where B: NearSemiring {
+  public static func + (f: Self, g: Self) -> Self {
     return .init { f.call($0) + g.call($0) }
   }
 
-  public static func * (f: Func, g: Func) -> Func {
+  public static func * (f: Self, g: Self) -> Self {
     return .init { f.call($0) * g.call($0) }
   }
 
-  public static var zero: Func {
+  public static var zero: Self {
     return .init(const(B.zero))
   }
 }
 
-extension Func: Semiring where B: Semiring {
-  public static var one: Func {
+extension Func: NearSemiring where B: NearSemiring {}
+
+extension Function where B: Semiring {
+  public static var one: Self {
     return .init(const(B.one))
   }
 }
+
+extension Func: Semiring where B: Semiring {}

--- a/Tests/PreludeTests/FunctionTests.swift
+++ b/Tests/PreludeTests/FunctionTests.swift
@@ -2,11 +2,46 @@ import XCTest
 import Prelude
 
 class FunctionTests: XCTestCase {
+  struct IntToString: Function {
+    static let live = IntToString(String.init)
+    
+    typealias Signature = (Int) -> String
+    
+    init(_ call: @escaping Signature) {
+      self.call = call
+    }
+    
+    let call: Signature
+    
+    func callAsFunction(integerValue: Int) -> String {
+      call(integerValue)
+    }
+  }
+  
   public func testCallAsFunction() {
     let increment = Func<Int, Int> { $0 + 1 }
     let zero = Func<Void, Int> { 0 }
     
     XCTAssertEqual(increment(0), 1)
     XCTAssertEqual(zero(), 0)
+  }
+  
+  public func testCustomCallAsFunction() {
+    let convert = IntToString.live
+    
+    XCTAssertEqual(convert(0), "0")
+    XCTAssertEqual(convert(integerValue: 1), "1")
+  }
+  
+  public func testTypeErasure() {
+    let convert = IntToString.live
+    let erasedConvert = convert.eraseToFunc()
+    
+    func typeIsFuncOfIntToString<F: Function>(_ f: F) -> Bool {
+      return f is Func<Int, String>
+    }
+    
+    XCTAssertTrue(typeIsFuncOfIntToString(erasedConvert))
+    XCTAssertEqual(convert(0), erasedConvert(0))
   }
 }

--- a/Tests/PreludeTests/FunctionTests.swift
+++ b/Tests/PreludeTests/FunctionTests.swift
@@ -2,4 +2,11 @@ import XCTest
 import Prelude
 
 class FunctionTests: XCTestCase {
+  public func testCallAsFunction() {
+    let increment = Func<Int, Int> { $0 + 1 }
+    let zero = Func<Void, Int> { 0 }
+    
+    XCTAssertEqual(increment(0), 1)
+    XCTAssertEqual(zero(), 0)
+  }
 }


### PR DESCRIPTION
- FuncProtocol added
- FuncProtocol.callAsFunction method added

I think that calling `Func` instances directly makes sense so I added this feature.
I implemented it as an extension for a `Function` protocol to enable users to implement their own specific function containers with this feature (may be useful when writing clients for TCA for example)

```swift
public struct CacheClient<Key: Hashable, Value> {
  public init(
    saveValue: CacheOperations.Save<Key, Value>,
    loadValue: CacheOperations.Load<Key, Value>,
    removeValue: CacheOperations.Remove<Key, Value>,
    removeAllValues: CacheOperations.RemoveAllValues<Key, Value>
  ) {
    self.saveValue = saveValue
    self.loadValue = loadValue
    self.removeValue = removeValue
    self.removeAllValues = removeAllValues
  }

  public var saveValue: CacheOperations.Save<Key, Value>
  public var loadValue: CacheOperations.Load<Key, Value>
  public var removeValue: CacheOperations.Remove<Key, Value>
  public var removeAllValues: CacheOperations.RemoveAllValues<Key, Value>
}

public enum CacheOperations {
  public struct Save<Key: Hashable, Value>: Function {
    public init(_ call: @escaping Signature) {
      self.call = call
    }

    public typealias Signature = ((Key, Value, Int?)) -> Void
    public let call: Signature
    public func callAsFunction(_ value: Value, withCost cost: Int? = nil, forKey key: Key) {
      call((key, value, cost))
    }
  }

  public struct Load<Key: Hashable, Value>: Function {
    public init(_ call: @escaping Signature) {
      self.call = call
    }

    public typealias Signature = (Key) -> Value?
    public let call: Signature
    public func callAsFunction(forKey key: Key) -> Value? { call(key) }
  }

  public struct Remove<Key: Hashable, Value>: Function {
    public init(_ call: @escaping Signature) {
      self. call = call
    }

    public typealias Signature = (Key) -> Void
    public let call: Signature
    public func callAsFunction(forKey key: Key) { call(key) }
  }

  public struct RemoveAllValues<Key: Hashable, Value>: Function {
    public init(_ call: @escaping Signature) {
      self.call = call
    }

    public typealias Signature = () -> Void
    public let call: Signature
  }
}
```

```swift
let cache = CacheClient<String, Data>.default()
cache.saveValue(data, withCost: data.count, forKey: "test") // You can override callAsFunction to get custom labels
cache.removeAllValues() // this `callAsFunction` method is provided by the `Function` protocol
```

-----

> _PS._ (_for someone, who may use it as an example_)
> For more specific clients I prefer creating:
> ```swift
> struct MyClient {}
> extension MyClient {
>  enum Operations {}
>}
>extension MyClient.Operations {
>  // ...
>}
>``` 
> But cache operations may be reused for `UserDefaultsClient` or `KeychinClient` for example (actually it can't be used because `UserDefaultsClient` and `KeychinClient` are pretty specific and they need their own operations declared, but at the moment I wrote `CacheClient` I didn't notice it yet 😅)

-----

> Also, I use my own protocol
> ```swift
> public protocol ActionContainer {
>  associatedtype Input
>  associatedtype Output
>  typealias Action = (Input) -> Output
>
>  init(action: @escaping Action)
>  var action: Action { get }
>}
>
>extension ActionContainer {
>  public func callAsFunction(_ input: Input) -> Output { action(input) }
>}
>
>extension ActionContainer where Input == Void {
>  public func callAsFunction() -> Output { action(()) }
>}
> ```
> But I noticed, that it's pretty the same, so that's why I implemented it here, so I'll be able to generalize code a bit 🌚
> And I wonder won't it be more expressive to use Input & Output associated types for `Function` protocol and `Func` type instead of `A` and `B`? It's a breaking change and may be released as a major update, but what's your point about it? 🙂
> (_I get that mathimatically it's maybe more expressive to use A&B to declare operators like `flatMap` etc, but at the call site it's not very convenient to see these type constraints_)