### PR TITLE
feat(SwiftPM): Update package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "Prelude",
+  name: "swift-prelude",
   products: [
     .library(name: "Either", targets: ["Either"]),
     .library(name: "Frp", targets: ["Frp"]),


### PR DESCRIPTION
I updated the package name to fit your other packages. Afaik difference with the repo name and a package name may lead to package resolution failures (_may be fixed by explicit name declaration when importing_) and also, there is some notion in the swift community including Apple and you for package names like `swift-format`, `swift-syntax`, `swift-collections`, `swift-composable-architecture`, etc. so I decided to update this package name too. I guess you know the tradeoffs, so I think it is worth creating a separate branch for the change.